### PR TITLE
Add unit tests (92% coverage) and fix E5/E6 bugs from issue #352

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build/
 .coverage
 .vscode
 tmp_testing*
+diagnostics/

--- a/docs/changes/352.bugfix.md
+++ b/docs/changes/352.bugfix.md
@@ -1,0 +1,5 @@
+Fix classification feature mismatch during application (E5): `process_file_chunked` now uses
+`features_tmva_style` when `tmva_style=True`, matching the training branch.
+
+Fix `AttributeError` in `configure_training` when `energy_bins_log10_tev` is absent from
+model parameters (E6): changed fallback default from `[]` (list, no `.get`) to `{}`.

--- a/src/eventdisplay_ml/config.py
+++ b/src/eventdisplay_ml/config.py
@@ -160,8 +160,8 @@ def configure_training(analysis_type):
         else:
             model_configs["tmva_style"] = bool(tmva_style_raw)
         model_configs["pre_cuts"] = pre_cuts_classification(
-            e_min=np.power(10.0, model_parameters.get("energy_bins_log10_tev", []).get("E_min")),
-            e_max=np.power(10.0, model_parameters.get("energy_bins_log10_tev", []).get("E_max")),
+            e_min=np.power(10.0, model_parameters.get("energy_bins_log10_tev", {}).get("E_min")),
+            e_max=np.power(10.0, model_parameters.get("energy_bins_log10_tev", {}).get("E_max")),
         )
         model_configs["energy_bins_log10_tev"] = model_parameters.get("energy_bins_log10_tev", [])
         model_configs["zenith_bins_deg"] = model_parameters.get("zenith_bins_deg", [])

--- a/src/eventdisplay_ml/config.py
+++ b/src/eventdisplay_ml/config.py
@@ -159,9 +159,16 @@ def configure_training(analysis_type):
             }
         else:
             model_configs["tmva_style"] = bool(tmva_style_raw)
+        e_bins = model_parameters.get("energy_bins_log10_tev", {})
+        e_min_log = e_bins.get("E_min")
+        e_max_log = e_bins.get("E_max")
+        if e_min_log is None or e_max_log is None:
+            raise ValueError(
+                "Model parameters must include 'energy_bins_log10_tev' with 'E_min' and 'E_max'."
+            )
         model_configs["pre_cuts"] = pre_cuts_classification(
-            e_min=np.power(10.0, model_parameters.get("energy_bins_log10_tev", {}).get("E_min")),
-            e_max=np.power(10.0, model_parameters.get("energy_bins_log10_tev", {}).get("E_max")),
+            e_min=np.power(10.0, e_min_log),
+            e_max=np.power(10.0, e_max_log),
         )
         model_configs["energy_bins_log10_tev"] = model_parameters.get("energy_bins_log10_tev", [])
         model_configs["zenith_bins_deg"] = model_parameters.get("zenith_bins_deg", [])

--- a/src/eventdisplay_ml/models.py
+++ b/src/eventdisplay_ml/models.py
@@ -441,9 +441,11 @@ def process_file_chunked(analysis_type, model_configs):
     tmva_style = model_configs.get("tmva_style", False)
     if tmva_style and analysis_type == "classification":
         branch_list = features.features_tmva_style(analysis_type, training=False)
-        branch_list = [b for b in branch_list if b not in {"ze_bin", "ArrayPointing_Azimuth"}] + [
-            "ArrayPointing_Elevation"
-        ]
+        # Auxiliary inputs needed for derived features and energy-bin selection.
+        branch_list = [b for b in branch_list if b not in {"ze_bin", "ArrayPointing_Azimuth"}]
+        for required in ("ArrayPointing_Elevation", "Erec"):
+            if required not in branch_list:
+                branch_list.append(required)
     else:
         branch_list = features.features(analysis_type, training=False)
     _logger.info(f"Using branches: {branch_list}")

--- a/src/eventdisplay_ml/models.py
+++ b/src/eventdisplay_ml/models.py
@@ -438,7 +438,14 @@ def process_file_chunked(analysis_type, model_configs):
     model_configs : dict
         Dictionary of model configurations.
     """
-    branch_list = features.features(analysis_type, training=False)
+    tmva_style = model_configs.get("tmva_style", False)
+    if tmva_style and analysis_type == "classification":
+        branch_list = features.features_tmva_style(analysis_type, training=False)
+        branch_list = [b for b in branch_list if b not in {"ze_bin", "ArrayPointing_Azimuth"}] + [
+            "ArrayPointing_Elevation"
+        ]
+    else:
+        branch_list = features.features(analysis_type, training=False)
     _logger.info(f"Using branches: {branch_list}")
     rename_map = {}
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -222,9 +222,8 @@ def test_configure_training_classification_missing_energy_bins_no_attribute_erro
         "load_model_parameters",
         lambda *_: {"tmva_style": False, "zenith_bins_deg": []},
     )
-    # Patch np.power so None exponents don't raise TypeError (we only care about no AttributeError)
-    monkeypatch.setattr(config.np, "power", lambda base, exp: exp)
-
+    # No energy bin information available: training config should fall back without crashing.
     result = config.configure_training("classification")
 
     assert result["energy_bins_log10_tev"] == []
+    assert result["pre_cuts"] == (0.0, 1e9)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,230 @@
+"""Tests for configure_training and configure_apply in config.py."""
+
+import json
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+from eventdisplay_ml import config
+
+
+@pytest.fixture
+def model_parameters_file(tmp_path):
+    path = tmp_path / "model_parameters.json"
+    path.write_text(
+        json.dumps(
+            {
+                "energy_bins_log10_tev": [{"E_min": -1.0, "E_max": 1.0}],
+                "zenith_bins_deg": [{"Ze_min": 0, "Ze_max": 20}],
+                "tmva_style": " yes ",
+            }
+        )
+    )
+    return path
+
+
+def test_configure_training_stereo_updates_models(monkeypatch):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "prog",
+            "--model_prefix",
+            "model",
+            "--input_file_list",
+            "inputs.txt",
+            "--max_cores",
+            "3",
+            "--random_state",
+            "7",
+            "--min_images",
+            "4",
+        ],
+    )
+    monkeypatch.setattr(
+        config,
+        "hyper_parameters",
+        lambda *_: {"xgboost": {"hyper_parameters": {}}, "warn": {"hyper_parameters": None}},
+    )
+    monkeypatch.setattr(config, "target_features", lambda *_: ["target_a"])
+    monkeypatch.setattr(config, "pre_cuts_regression", lambda min_images: f"cut_{min_images}")
+
+    result = config.configure_training("stereo_analysis")
+
+    assert result["models"]["xgboost"]["hyper_parameters"] == {"n_jobs": 3, "random_state": 7}
+    assert result["pre_cuts"] == "cut_4"
+    assert result["targets"] == ["target_a"]
+
+
+def test_configure_training_classification_parses_tmva_style(monkeypatch, model_parameters_file):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "prog",
+            "--model_prefix",
+            "model",
+            "--input_signal_file_list",
+            "signal.txt",
+            "--input_background_file_list",
+            "background.txt",
+            "--model_parameters",
+            str(model_parameters_file),
+            "--energy_bin_number",
+            "0",
+            "--max_cores",
+            "2",
+        ],
+    )
+    monkeypatch.setattr(
+        config, "hyper_parameters", lambda *_: {"xgboost": {"hyper_parameters": {}}}
+    )
+    monkeypatch.setattr(config, "target_features", lambda *_: ["label"])
+    monkeypatch.setattr(config, "pre_cuts_classification", lambda e_min, e_max: (e_min, e_max))
+
+    result = config.configure_training("classification")
+
+    assert result["tmva_style"] is True
+    assert result["pre_cuts"][0] == pytest.approx(0.1)
+    assert result["pre_cuts"][1] == pytest.approx(10.0)
+    assert result["energy_bins_log10_tev"]["E_min"] == pytest.approx(-1.0)
+    assert result["models"]["xgboost"]["hyper_parameters"]["n_jobs"] == 2
+
+
+def test_configure_training_classification_handles_boolean_tmva_style(monkeypatch, tmp_path):
+    params_path = tmp_path / "params.json"
+    params_path.write_text(
+        json.dumps(
+            {
+                "energy_bins_log10_tev": [{"E_min": 0.0, "E_max": 0.5}],
+                "zenith_bins_deg": [],
+                "tmva_style": False,
+            }
+        )
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "prog",
+            "--model_prefix",
+            "model",
+            "--input_signal_file_list",
+            "signal.txt",
+            "--input_background_file_list",
+            "background.txt",
+            "--model_parameters",
+            str(params_path),
+        ],
+    )
+    monkeypatch.setattr(
+        config, "hyper_parameters", lambda *_: {"xgboost": {"hyper_parameters": {}}}
+    )
+    monkeypatch.setattr(config, "target_features", lambda *_: ["label"])
+    monkeypatch.setattr(config, "pre_cuts_classification", lambda **_: "cuts")
+
+    result = config.configure_training("classification")
+
+    assert result["tmva_style"] is False
+    assert result["pre_cuts"] == "cuts"
+
+
+def test_configure_apply_stereo_loads_scalers(monkeypatch):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "prog",
+            "--input_file",
+            "input.root",
+            "--model_prefix",
+            "model",
+            "--output_file",
+            "output.root",
+            "--model_name",
+            "custom",
+        ],
+    )
+    load_models = MagicMock(
+        return_value=(
+            {"custom": {"model": object()}},
+            {
+                "energy_bins_log10_tev": [{"E_min": -1.0, "E_max": 1.0}],
+                "zenith_bins_deg": [{"Ze_min": 0, "Ze_max": 20}],
+                "target_mean": {"Xoff_residual": 0.0},
+                "target_std": {"Xoff_residual": 1.0},
+            },
+        )
+    )
+    monkeypatch.setattr(config, "load_models", load_models)
+
+    result = config.configure_apply("stereo_analysis")
+
+    load_models.assert_called_once_with("stereo_analysis", "model", "custom")
+    assert result["target_mean"]["Xoff_residual"] == pytest.approx(0.0)
+    assert result["target_std"]["Xoff_residual"] == pytest.approx(1.0)
+
+
+def test_configure_apply_classification_omits_regression_scalers(monkeypatch):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "prog",
+            "--input_file",
+            "input.root",
+            "--model_prefix",
+            "model",
+            "--output_file",
+            "out.root",
+        ],
+    )
+    monkeypatch.setattr(
+        config, "load_models", lambda *_: ({0: {"model": object()}}, {"zenith_bins_deg": []})
+    )
+
+    result = config.configure_apply("classification")
+
+    assert "target_mean" not in result
+    assert result["models"][0]["model"] is not None
+
+
+def test_configure_training_classification_missing_energy_bins_no_attribute_error(
+    monkeypatch, tmp_path
+):
+    """Regression test for E6: missing energy_bins_log10_tev must not raise AttributeError."""
+    params_path = tmp_path / "params_no_bins.json"
+    params_path.write_text(json.dumps({}))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "prog",
+            "--model_prefix",
+            "model",
+            "--input_signal_file_list",
+            "signal.txt",
+            "--input_background_file_list",
+            "background.txt",
+            "--model_parameters",
+            str(params_path),
+        ],
+    )
+    monkeypatch.setattr(
+        config, "hyper_parameters", lambda *_: {"xgboost": {"hyper_parameters": {}}}
+    )
+    monkeypatch.setattr(config, "target_features", lambda *_: ["label"])
+    monkeypatch.setattr(config, "pre_cuts_classification", lambda e_min, e_max: (e_min, e_max))
+    # Return params without energy_bins_log10_tev to trigger the fallback path
+    monkeypatch.setattr(
+        config.utils,
+        "load_model_parameters",
+        lambda *_: {"tmva_style": False, "zenith_bins_deg": []},
+    )
+    # Patch np.power so None exponents don't raise TypeError (we only care about no AttributeError)
+    monkeypatch.setattr(config.np, "power", lambda base, exp: exp)
+
+    result = config.configure_training("classification")
+
+    assert result["energy_bins_log10_tev"] == []

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -190,10 +190,10 @@ def test_configure_apply_classification_omits_regression_scalers(monkeypatch):
     assert result["models"][0]["model"] is not None
 
 
-def test_configure_training_classification_missing_energy_bins_no_attribute_error(
+def test_configure_training_classification_missing_energy_bins_raises_clear_error(
     monkeypatch, tmp_path
 ):
-    """Regression test for E6: missing energy_bins_log10_tev must not raise AttributeError."""
+    """Regression test for E6: missing energy_bins_log10_tev must raise a clear ValueError."""
     params_path = tmp_path / "params_no_bins.json"
     params_path.write_text(json.dumps({}))
     monkeypatch.setattr(
@@ -222,8 +222,5 @@ def test_configure_training_classification_missing_energy_bins_no_attribute_erro
         "load_model_parameters",
         lambda *_: {"tmva_style": False, "zenith_bins_deg": []},
     )
-    # No energy bin information available: training config should fall back without crashing.
-    result = config.configure_training("classification")
-
-    assert result["energy_bins_log10_tev"] == []
-    assert result["pre_cuts"] == (0.0, 1e9)
+    with pytest.raises(ValueError, match=r"E_min.*E_max|energy_bins_log10_tev"):
+        config.configure_training("classification")

--- a/tests/test_data_helpers.py
+++ b/tests/test_data_helpers.py
@@ -1,0 +1,391 @@
+"""Unit tests for pure helper functions in data_processing.py."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from eventdisplay_ml.data_processing import (
+    _calculate_array_footprint,
+    _clip_size_array,
+    _compute_telescope_indices_to_keep,
+    _get_index,
+    _ground_to_shower_coords,
+    _has_field,
+    _make_mirror_area_columns,
+    _make_tel_active_columns,
+    _to_dense_array,
+    _to_numpy_1d,
+    apply_clip_intervals,
+    energy_in_bins,
+)
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def simple_tel_config():
+    """Minimal telescope configuration for 4 telescopes with equal mirror area."""
+    return {
+        "tel_ids": np.array([0, 1, 2, 3]),
+        "mirror_area": np.array([100.0, 100.0, 100.0, 100.0]),
+        "mirror_areas": np.array([100.0, 100.0, 100.0, 100.0]),
+        "tel_x": np.array([0.0, 100.0, -100.0, 0.0]),
+        "tel_y": np.array([0.0, 0.0, 0.0, 100.0]),
+        "max_tel_id": 3,
+    }
+
+
+@pytest.fixture
+def mixed_area_tel_config():
+    """6-telescope config with two mirror area types: 200 m² (0,1,2) and 50 m² (3,4,5)."""
+    return {
+        "tel_ids": np.array([0, 1, 2, 3, 4, 5]),
+        "mirror_area": np.array([200.0, 200.0, 200.0, 50.0, 50.0, 50.0]),
+        "mirror_areas": np.array([200.0, 200.0, 200.0, 50.0, 50.0, 50.0]),
+        "tel_x": np.zeros(6),
+        "tel_y": np.zeros(6),
+        "max_tel_id": 5,
+    }
+
+
+# ---------------------------------------------------------------------------
+# _to_dense_array
+# ---------------------------------------------------------------------------
+
+
+def test_to_dense_array_regular_series():
+    col = pd.Series([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    result = _to_dense_array(col)
+    assert result.shape == (2, 3)
+    np.testing.assert_allclose(result, [[1, 2, 3], [4, 5, 6]])
+
+
+def test_to_dense_array_variable_length_pads_with_nan():
+    col = pd.Series([[1.0, 2.0], [3.0, 4.0, 5.0]])
+    result = _to_dense_array(col)
+    assert result.shape == (2, 3)
+    assert np.isnan(result[0, 2])
+    np.testing.assert_allclose(result[0, :2], [1.0, 2.0])
+    np.testing.assert_allclose(result[1], [3.0, 4.0, 5.0])
+
+
+def test_to_dense_array_numpy_arrays():
+    col = pd.Series([np.array([1.0, 2.0]), np.array([3.0, 4.0, 5.0])])
+    result = _to_dense_array(col)
+    assert result.shape == (2, 3)
+
+
+# ---------------------------------------------------------------------------
+# _to_numpy_1d
+# ---------------------------------------------------------------------------
+
+
+def test_to_numpy_1d_from_series():
+    s = pd.Series([1.0, 2.0, 3.0])
+    result = _to_numpy_1d(s, np.float32)
+    assert isinstance(result, np.ndarray)
+    assert result.dtype == np.float32
+    np.testing.assert_allclose(result, [1.0, 2.0, 3.0])
+
+
+def test_to_numpy_1d_from_numpy_array():
+    arr = np.array([4.0, 5.0, 6.0])
+    result = _to_numpy_1d(arr, np.float32)
+    assert result.dtype == np.float32
+
+
+def test_to_numpy_1d_from_list():
+    result = _to_numpy_1d([1, 2, 3], np.float64)
+    assert result.dtype == np.float64
+    np.testing.assert_allclose(result, [1.0, 2.0, 3.0])
+
+
+# ---------------------------------------------------------------------------
+# _has_field
+# ---------------------------------------------------------------------------
+
+
+def test_has_field_dataframe_present():
+    df = pd.DataFrame({"a": [1], "b": [2]})
+    assert _has_field(df, "a") is True
+    assert _has_field(df, "c") is False
+
+
+def test_has_field_dict():
+    d = {"key1": 1}
+    assert _has_field(d, "key1") is True
+    assert _has_field(d, "missing") is False
+
+
+# ---------------------------------------------------------------------------
+# _get_index
+# ---------------------------------------------------------------------------
+
+
+def test_get_index_from_dataframe():
+    idx = pd.RangeIndex(5, 10)
+    df = pd.DataFrame({"a": range(5)}, index=idx)
+    result = _get_index(df, 5)
+    assert list(result) == list(idx)
+
+
+def test_get_index_from_non_dataframe():
+    result = _get_index([1, 2, 3], 3)
+    assert isinstance(result, pd.RangeIndex)
+    assert len(result) == 3
+
+
+# ---------------------------------------------------------------------------
+# _clip_size_array
+# ---------------------------------------------------------------------------
+
+
+def test_clip_size_array_clips_to_minimum():
+    arr = np.array([[0.0, 0.5, 1.0, 200.0]])
+    result = _clip_size_array(arr)
+    assert result[0, 0] == pytest.approx(1.0)  # vmin=1 from clip_intervals
+    assert result[0, 1] == pytest.approx(1.0)
+    assert result[0, 2] == pytest.approx(1.0)
+    assert result[0, 3] == pytest.approx(200.0)
+
+
+def test_clip_size_array_preserves_nan():
+    arr = np.array([[np.nan, 50.0, np.nan]])
+    result = _clip_size_array(arr)
+    assert np.isnan(result[0, 0])
+    assert np.isnan(result[0, 2])
+    assert result[0, 1] == pytest.approx(50.0)
+
+
+# ---------------------------------------------------------------------------
+# _ground_to_shower_coords
+# ---------------------------------------------------------------------------
+
+
+def test_ground_to_shower_coords_zero_input():
+    x = np.array([0.0])
+    y = np.array([0.0])
+    sx, sy = _ground_to_shower_coords(x, y, np.array([0.0]), np.array([1.0]), np.array([1.0]))
+    assert sx[0] == pytest.approx(0.0)
+    assert sy[0] == pytest.approx(0.0)
+
+
+def test_ground_to_shower_coords_zero_elevation_gives_zero_y():
+    """sin(elevation)=0 → shower_y must be zero regardless of input."""
+    x = np.array([3.0])
+    y = np.array([4.0])
+    _, sy = _ground_to_shower_coords(x, y, np.array([0.5]), np.array([0.866]), np.array([0.0]))
+    assert sy[0] == pytest.approx(0.0)
+
+
+def test_ground_to_shower_coords_output_shape():
+    n = 10
+    x = np.random.default_rng(0).uniform(-200, 200, n)
+    y = np.random.default_rng(1).uniform(-200, 200, n)
+    sin_az = np.sin(np.radians(30.0)) * np.ones(n)
+    cos_az = np.cos(np.radians(30.0)) * np.ones(n)
+    sin_el = np.sin(np.radians(60.0)) * np.ones(n)
+    sx, sy = _ground_to_shower_coords(x, y, sin_az, cos_az, sin_el)
+    assert sx.shape == (n,)
+    assert sy.shape == (n,)
+
+
+# ---------------------------------------------------------------------------
+# _make_mirror_area_columns
+# ---------------------------------------------------------------------------
+
+
+def test_make_mirror_area_columns_assigns_correct_values(simple_tel_config):
+    n_evt = 3
+    max_tel_id = 3
+    result = _make_mirror_area_columns(simple_tel_config, max_tel_id, n_evt)
+    assert set(result.keys()) == {f"mirror_area_{i}" for i in range(4)}
+    for i in range(4):
+        np.testing.assert_allclose(result[f"mirror_area_{i}"], [100.0, 100.0, 100.0])
+
+
+def test_make_mirror_area_columns_missing_key_raises():
+    bad_config = {"tel_ids": np.array([0]), "tel_x": np.zeros(1), "tel_y": np.zeros(1)}
+    with pytest.raises(KeyError):
+        _make_mirror_area_columns(bad_config, max_tel_id=0, n_evt=1)
+
+
+# ---------------------------------------------------------------------------
+# _make_tel_active_columns
+# ---------------------------------------------------------------------------
+
+
+def test_make_tel_active_columns_marks_active_telescopes():
+    # tel_list_matrix: event 0 has tel 0,1,2 active; event 1 has tel 1,3 active
+    tel_list_matrix = np.array([[0.0, 1.0, 2.0, np.nan], [np.nan, 1.0, np.nan, 3.0]])
+    result = _make_tel_active_columns(tel_list_matrix, max_tel_id=3, n_evt=2)
+    assert result["tel_active_0"][0] == pytest.approx(1.0)
+    assert result["tel_active_1"][0] == pytest.approx(1.0)
+    assert result["tel_active_2"][0] == pytest.approx(1.0)
+    assert result["tel_active_3"][0] == pytest.approx(0.0)  # not active in event 0
+    assert result["tel_active_0"][1] == pytest.approx(0.0)  # not active in event 1
+    assert result["tel_active_1"][1] == pytest.approx(1.0)
+    assert result["tel_active_3"][1] == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# _compute_telescope_indices_to_keep
+# ---------------------------------------------------------------------------
+
+
+def test_compute_telescope_indices_to_keep_none_returns_all(simple_tel_config):
+    result = _compute_telescope_indices_to_keep(
+        simple_tel_config, max_tel_id=3, max_tel_per_type=None
+    )
+    assert result == [0, 1, 2, 3]
+
+
+def test_compute_telescope_indices_to_keep_limits_per_type(mixed_area_tel_config):
+    result = _compute_telescope_indices_to_keep(
+        mixed_area_tel_config, max_tel_id=5, max_tel_per_type=1
+    )
+    # Should keep 1 from the large-area group and 1 from the small-area group
+    assert len(result) == 2
+
+
+def test_compute_telescope_indices_to_keep_max_per_type_two(mixed_area_tel_config):
+    result = _compute_telescope_indices_to_keep(
+        mixed_area_tel_config, max_tel_id=5, max_tel_per_type=2
+    )
+    assert len(result) == 4  # 2 from each group of 3
+
+
+def test_compute_telescope_indices_to_keep_larger_than_group_keeps_all(mixed_area_tel_config):
+    result = _compute_telescope_indices_to_keep(
+        mixed_area_tel_config, max_tel_id=5, max_tel_per_type=10
+    )
+    assert len(result) == 6  # All telescopes kept since 10 > group sizes
+
+
+# ---------------------------------------------------------------------------
+# apply_clip_intervals
+# ---------------------------------------------------------------------------
+
+
+def test_apply_clip_intervals_clips_scalar_column():
+    df = pd.DataFrame({"MSCW": [-5.0, 0.0, 5.0]})
+    apply_clip_intervals(df)
+    # MSCW clip is (-2, 2)
+    assert df["MSCW"].iloc[0] == pytest.approx(-2.0)
+    assert df["MSCW"].iloc[2] == pytest.approx(2.0)
+    assert df["MSCW"].iloc[1] == pytest.approx(0.0)
+
+
+def test_apply_clip_intervals_preserves_nan():
+    df = pd.DataFrame({"MSCW": [-5.0, np.nan, 5.0]})
+    apply_clip_intervals(df)
+    assert np.isnan(df["MSCW"].iloc[1])
+
+
+def test_apply_clip_intervals_applies_log10():
+    df = pd.DataFrame({"Erec": [0.001, 0.1, 1.0, 10.0]})
+    apply_clip_intervals(df, apply_log10=["Erec"])
+    # Erec should be log10-transformed for valid values
+    # vmin for Erec = 1e-3, so 0.001 is at min, stays at 1e-3, log10 = -3
+    assert df["Erec"].iloc[2] == pytest.approx(0.0)  # log10(1.0) = 0
+    assert df["Erec"].iloc[3] == pytest.approx(1.0)  # log10(10.0) = 1
+
+
+def test_apply_clip_intervals_per_telescope_column():
+    df = pd.DataFrame({"tgrad_x_0": [-100.0, 0.0, 100.0], "tgrad_x_1": [0.0, 0.0, 0.0]})
+    apply_clip_intervals(df, n_tel=2)
+    # tgrad_x clip is (-50, 50)
+    assert df["tgrad_x_0"].iloc[0] == pytest.approx(-50.0)
+    assert df["tgrad_x_0"].iloc[2] == pytest.approx(50.0)
+
+
+# ---------------------------------------------------------------------------
+# energy_in_bins
+# ---------------------------------------------------------------------------
+
+
+def test_energy_in_bins_assigns_nearest_bin():
+    # Use energies well inside each bin to avoid tie-breaking at shared edges.
+    # Bins have centers -1.5, -0.5, 0.5, 1.5 in log10(E/TeV).
+    df = pd.DataFrame({"Erec": [0.003, 0.2, 5.0, 50.0]})
+    bins = [
+        {"E_min": -2.0, "E_max": -1.0},  # center = -1.5
+        {"E_min": -1.0, "E_max": 0.0},  # center = -0.5
+        {"E_min": 0.0, "E_max": 1.0},  # center =  0.5
+        {"E_min": 1.0, "E_max": 2.0},  # center =  1.5
+    ]
+    result = energy_in_bins(df, bins)
+    assert result.iloc[0] == 0  # log10(0.003) ≈ -2.5 → nearest to bin 0
+    assert result.iloc[1] == 1  # log10(0.2)   ≈ -0.7 → nearest to bin 1
+    assert result.iloc[2] == 2  # log10(5.0)   ≈  0.7 → nearest to bin 2
+    assert result.iloc[3] == 3  # log10(50.0)  ≈  1.7 → nearest to bin 3
+
+
+def test_energy_in_bins_invalid_erec_returns_minus_one():
+    df = pd.DataFrame({"Erec": [0.0, -1.0, np.nan, 1.0]})
+    bins = [{"E_min": -1.0, "E_max": 1.0}]
+    result = energy_in_bins(df, bins)
+    assert result.iloc[0] == -1  # Erec=0 is invalid
+    assert result.iloc[1] == -1  # Erec<0 is invalid
+
+
+# ---------------------------------------------------------------------------
+# _calculate_array_footprint
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def square_tel_config():
+    """4 telescopes at corners of a 200x200m square."""
+    return {
+        "tel_ids": np.array([0, 1, 2, 3]),
+        "tel_x": np.array([-100.0, 100.0, 100.0, -100.0]),
+        "tel_y": np.array([-100.0, -100.0, 100.0, 100.0]),
+    }
+
+
+def test_calculate_array_footprint_two_tel_returns_distance():
+    # _calculate_array_footprint builds lookup_x[0..max_id] from tel_list_matrix values,
+    # so tel_config must not contain IDs beyond max(tel_list_matrix values).
+    tel_config = {
+        "tel_ids": np.array([0, 1]),
+        "tel_x": np.array([-100.0, 100.0]),
+        "tel_y": np.array([0.0, 0.0]),
+    }
+    tel_list_matrix = np.array([[0.0, 1.0]])
+    result = _calculate_array_footprint(tel_config, tel_list_matrix)
+    assert result[0] == pytest.approx(200.0)
+
+
+def test_calculate_array_footprint_three_tel_returns_positive():
+    tel_config = {
+        "tel_ids": np.array([0, 1, 2]),
+        "tel_x": np.array([0.0, 100.0, 50.0]),
+        "tel_y": np.array([0.0, 0.0, 100.0]),
+    }
+    tel_list_matrix = np.array([[0.0, 1.0, 2.0]])
+    result = _calculate_array_footprint(tel_config, tel_list_matrix)
+    assert result[0] > 0.0
+
+
+def test_calculate_array_footprint_single_tel_returns_minus_one():
+    tel_config = {
+        "tel_ids": np.array([0]),
+        "tel_x": np.array([0.0]),
+        "tel_y": np.array([0.0]),
+    }
+    # Only one valid (non-NaN) entry → not enough telescopes → -1
+    tel_list_matrix = np.array([[0.0]])
+    result = _calculate_array_footprint(tel_config, tel_list_matrix)
+    assert result[0] == pytest.approx(-1.0)
+
+
+def test_calculate_array_footprint_multiple_events(square_tel_config):
+    tel_list_matrix = np.array([[0.0, 1.0], [2.0, 3.0], [0.0, np.nan]])
+    result = _calculate_array_footprint(square_tel_config, tel_list_matrix)
+    assert len(result) == 3
+    assert result[0] == pytest.approx(200.0)
+    assert result[1] == pytest.approx(200.0)
+    assert result[2] == pytest.approx(-1.0)

--- a/tests/test_data_processing_remaining.py
+++ b/tests/test_data_processing_remaining.py
@@ -1,0 +1,269 @@
+"""Tests for remaining data_processing helper branches."""
+
+from unittest.mock import MagicMock
+
+import awkward as ak
+import numpy as np
+import pandas as pd
+import pytest
+from conftest import create_base_df
+
+from eventdisplay_ml import data_processing
+
+
+@pytest.fixture
+def tel_config():
+    return {
+        "n_tel": 2,
+        "tel_ids": np.array([0, 1]),
+        "mirror_area": np.array([100.0, 50.0]),
+        "mirror_areas": np.array([100.0, 50.0]),
+        "tel_x": np.array([0.0, 100.0]),
+        "tel_y": np.array([0.0, 0.0]),
+        "max_tel_id": 1,
+        "tel_types": {100.0: [0], 50.0: [1]},
+    }
+
+
+@pytest.fixture
+def awkward_records():
+    return ak.Array(
+        [
+            {"DispTelList_T": [0, 1], "old": [1.0, 2.0]},
+            {"DispTelList_T": [0], "old": [3.0]},
+        ]
+    )
+
+
+def test_read_telescope_config_groups_telescopes():
+    telconfig_tree = MagicMock()
+    telconfig_tree.arrays.return_value = {
+        "NTel": np.array([2]),
+        "TelID": np.array([0, 1]),
+        "MirrorArea": np.array([100.0, 50.0]),
+        "TelX": np.array([0.0, 100.0]),
+        "TelY": np.array([0.0, 0.0]),
+    }
+    root_file = {"telconfig": telconfig_tree}
+
+    result = data_processing.read_telescope_config(root_file)
+
+    assert result["n_tel"] == 2
+    assert result["max_tel_id"] == 1
+    assert result["tel_types"][100.0] == [0]
+
+
+def test_resolve_branch_aliases_handles_fallback_and_missing_optional(caplog):
+    tree = MagicMock()
+    tree.keys.return_value = {"R", "size", "Erec"}
+    resolved, rename = data_processing._resolve_branch_aliases(
+        tree,
+        ["R_core", "mirror_area", "size", "fpointing_dx", "Erec", "SizeSecondMax"],
+    )
+    assert resolved == ["R", "size", "Erec"]
+    assert rename == {"R": "R_core"}
+
+    tree.keys.return_value = {"size"}
+    missing, _ = data_processing._resolve_branch_aliases(tree, ["R_core", "size"])
+    assert missing == ["size"]
+    assert "fallback 'R' not found" in caplog.text
+
+
+def test_ensure_fpointing_fields_and_rename_fields(awkward_records):
+    ensured = data_processing._ensure_fpointing_fields(awkward_records)
+    renamed = data_processing._rename_fields(ensured, {"old": "new"})
+    assert "fpointing_dx" in renamed.fields
+    assert "fpointing_dy" in renamed.fields
+    assert ak.to_list(renamed["new"])[0] == [1.0, 2.0]
+    assert "old" not in renamed.fields
+
+
+def test_to_dense_array_and_numpy_helpers_cover_remaining_branches():
+    dense = data_processing._to_dense_array(ak.Array([[1.0, 2.0], [3.0]]))
+    assert dense.shape == (2, 2)
+    assert np.isnan(dense[1, 1])
+
+    with pytest.raises(ValueError, match="convertible"):
+        data_processing._to_dense_array(42)
+
+    fallback = data_processing._to_numpy_1d([1, 2], np.float32)
+    awkward_array = data_processing._to_numpy_1d(ak.Array([1, 2]), np.float32)
+    assert fallback.dtype == np.float32
+    assert awkward_array.tolist() == [1.0, 2.0]
+
+
+def test_has_field_supports_awkward_and_fallback():
+    assert data_processing._has_field(ak.Array([{"field": 1}]), "field") is True
+
+    class BrokenContains:
+        def __contains__(self, _):
+            raise TypeError("bad")
+
+    assert data_processing._has_field(BrokenContains(), "field") is False
+
+
+def test_flatten_feature_data_drops_size_columns_for_classification(tel_config):
+    df = create_base_df(n_rows=2, n_tel=2)
+    df["ImgSel_list"] = [np.array([0, 1]), np.array([0, 1])]
+    df["MSCW"] = [1.0, 2.0]
+    df["MSCL"] = [0.1, 0.2]
+    df["EChi2S"] = [4.0, 5.0]
+    df["EmissionHeight"] = [100.0, 120.0]
+    df["EmissionHeightChi2"] = [6.0, 7.0]
+    df["Xcore"] = [10.0, 20.0]
+    df["Ycore"] = [0.0, 5.0]
+    df["DispAbsSumWeigth"] = [1.0, 2.0]
+    df["ArrayPointing_Azimuth"] = [0.0, 10.0]
+    df["ArrayPointing_Elevation"] = [70.0, 65.0]
+    df["ze_bin"] = [0, 1]
+
+    result = data_processing.flatten_feature_data(
+        df,
+        2,
+        "classification",
+        training=False,
+        tel_config=tel_config,
+        observatory="ctao",
+        preview_rows=0,
+    )
+
+    assert "size_0" not in result.columns
+    assert "cosphi_0" in result.columns
+    assert "ze_bin" in result.columns
+
+
+def test_calculate_array_footprint_returns_negative_one_on_value_error(tel_config, monkeypatch):
+    monkeypatch.setattr(
+        data_processing, "ConvexHull", lambda *_: (_ for _ in ()).throw(ValueError("bad"))
+    )
+    footprints = data_processing._calculate_array_footprint(tel_config, np.array([[0.0, 1.0, 1.0]]))
+    assert footprints[0] == pytest.approx(-1.0)
+
+
+def test_extra_columns_classification_handles_optional_columns():
+    df = pd.DataFrame(
+        {
+            "MSCW": [1.0],
+            "MSCL": [2.0],
+            "EChi2S": [10.0],
+            "EmissionHeight": [100.0],
+            "EmissionHeightChi2": [5.0],
+            "SizeSecondMax": [1000.0],
+            "Xcore": [3.0],
+            "Ycore": [4.0],
+            "DispAbsSumWeigth": [7.0],
+            "ze_bin": [2],
+        }
+    )
+    result = data_processing.extra_columns(df, "classification", False, df.index)
+    assert result.loc[0, "Core_Distance"] == pytest.approx(5.0)
+    assert result.loc[0, "DispAbsSumWeigth"] == pytest.approx(5.0)
+    assert result.loc[0, "ze_bin"] == pytest.approx(2.0)
+    assert result.loc[0, "SizeSecondMax"] == pytest.approx(3.0)
+
+
+def test_energy_interpolation_bins_handles_edge_cases():
+    empty = pd.DataFrame({"Erec": []})
+    invalid = pd.DataFrame({"Erec": [0.0, -1.0]})
+    single = pd.DataFrame({"Erec": [1.0, 10.0]})
+    bins = [{"E_min": -1.0, "E_max": 1.0}]
+    nan_bins = [None]
+
+    assert np.all(data_processing.energy_interpolation_bins(empty, bins)[0] == -1)
+    assert np.all(data_processing.energy_interpolation_bins(single, nan_bins)[0] == -1)
+    assert np.all(data_processing.energy_interpolation_bins(invalid, bins)[0] == -1)
+    lo, hi, alpha = data_processing.energy_interpolation_bins(single, bins)
+    assert lo.tolist() == [0, 0]
+    assert hi.tolist() == [0, 0]
+    assert alpha.tolist() == pytest.approx([0.0, 0.0])
+
+
+def test_print_variable_statistics_handles_empty_and_non_empty_columns(caplog, capsys):
+    df = pd.DataFrame({"filled": [1.0, 3.0], "empty": [np.nan, np.nan]})
+    with caplog.at_level("INFO"):
+        data_processing.print_variable_statistics(df)
+    assert "filled" in caplog.text
+    assert "empty: No data" in capsys.readouterr().out
+
+
+def test_load_training_data_tmva_style_classification(monkeypatch, tel_config):
+    arrays = ak.Array(
+        [
+            {"ArrayPointing_Elevation": 70.0, "ArrayPointing_Azimuth": 30.0, "MSCW": 1.0},
+            {"ArrayPointing_Elevation": 40.0, "ArrayPointing_Azimuth": 40.0, "MSCW": 2.0},
+        ]
+    )
+    tree = MagicMock()
+    tree.num_entries = 2
+    tree.arrays.return_value = arrays
+    root_file = MagicMock()
+    root_file.__enter__.return_value = {"data": tree, "telconfig": MagicMock()}
+    root_file.__exit__.return_value = False
+    monkeypatch.setattr(data_processing.utils, "read_input_file_list", lambda _: ["file.root"])
+    monkeypatch.setattr(data_processing.uproot, "open", lambda _: root_file)
+    monkeypatch.setattr(data_processing, "read_telescope_config", lambda _: tel_config)
+    monkeypatch.setattr(
+        data_processing, "_resolve_branch_aliases", lambda tree, branches: (branches, {})
+    )
+    monkeypatch.setattr(data_processing, "_ensure_fpointing_fields", lambda arr: arr)
+    monkeypatch.setattr(
+        data_processing.features_module,
+        "features_tmva_style",
+        lambda *_args, **_kwargs: ["MSCW", "ze_bin", "ArrayPointing_Azimuth"],
+    )
+    monkeypatch.setattr(data_processing, "print_variable_statistics", lambda *_: None)
+
+    result = data_processing.load_training_data(
+        {
+            "tmva_style": True,
+            "zenith_bins_deg": [{"Ze_min": 0, "Ze_max": 30}, {"Ze_min": 30, "Ze_max": 60}],
+            "max_cores": 1,
+        },
+        "inputs.txt",
+        "classification",
+    )
+
+    assert "ArrayPointing_Azimuth" not in result.columns
+    assert "ArrayPointing_Elevation" not in result.columns
+    assert result["ze_bin"].tolist() == [0, 1]
+
+
+def test_load_training_data_stereo_adds_residuals(monkeypatch, tel_config):
+    arrays = ak.Array(
+        [
+            {"MCxoff": 1.2, "MCyoff": 2.1, "MCe0": 10.0},
+            {"MCxoff": 1.4, "MCyoff": 2.4, "MCe0": 100.0},
+        ]
+    )
+    tree = MagicMock()
+    tree.num_entries = 2
+    tree.arrays.return_value = arrays
+    root_data = {"data": tree, "telconfig": MagicMock()}
+    root_file = MagicMock()
+    root_file.__enter__.return_value = root_data
+    root_file.__exit__.return_value = False
+    monkeypatch.setattr(data_processing.utils, "read_input_file_list", lambda _: ["file.root"])
+    monkeypatch.setattr(data_processing.uproot, "open", lambda _: root_file)
+    monkeypatch.setattr(data_processing, "read_telescope_config", lambda _: tel_config)
+    monkeypatch.setattr(
+        data_processing, "_resolve_branch_aliases", lambda tree, branches: (branches, {})
+    )
+    monkeypatch.setattr(data_processing, "_ensure_fpointing_fields", lambda arr: arr)
+    monkeypatch.setattr(
+        data_processing,
+        "flatten_telescope_data_vectorized",
+        lambda *args, **kwargs: pd.DataFrame(
+            {
+                "Xoff_weighted_bdt": [1.0, 1.0],
+                "Yoff_weighted_bdt": [2.0, 2.0],
+                "ErecS": [5.0, 10.0],
+            }
+        ),
+    )
+    monkeypatch.setattr(data_processing, "print_variable_statistics", lambda *_: None)
+
+    result = data_processing.load_training_data({"max_cores": 1}, "inputs.txt", "stereo_analysis")
+
+    assert result["Xoff_residual"].tolist() == pytest.approx([0.2, 0.4])
+    assert result["Yoff_residual"].tolist() == pytest.approx([0.1, 0.4])
+    assert result["E_residual"].tolist() == pytest.approx([np.log10(10.0) - np.log10(5.0), 1.0])

--- a/tests/test_diagnostic_utils.py
+++ b/tests/test_diagnostic_utils.py
@@ -1,0 +1,66 @@
+"""Unit tests for pure computation functions in diagnostic_utils.py."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from eventdisplay_ml.diagnostic_utils import compute_generalization_metrics
+
+# ---------------------------------------------------------------------------
+# compute_generalization_metrics
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def perfect_predictions():
+    """Train and test DataFrames where predictions match exactly."""
+    targets = ["Xoff_residual", "Yoff_residual"]
+    data = {t: np.array([0.0, 1.0, 2.0, 3.0]) for t in targets}
+    y = pd.DataFrame(data)
+    return y, y.copy(), y, y.copy(), targets
+
+
+def test_compute_generalization_metrics_perfect_gives_zero_rmse(perfect_predictions):
+    y_train, y_train_pred, y_test, y_test_pred, targets = perfect_predictions
+    metrics = compute_generalization_metrics(y_train, y_train_pred, y_test, y_test_pred, targets)
+    for t in targets:
+        assert metrics[t]["rmse_train"] == pytest.approx(0.0)
+        assert metrics[t]["rmse_test"] == pytest.approx(0.0)
+
+
+def test_compute_generalization_metrics_keys_present():
+    targets = ["E_residual"]
+    y = pd.DataFrame({"E_residual": [1.0, 2.0, 3.0]})
+    pred = pd.DataFrame({"E_residual": [1.1, 2.1, 2.9]})
+    metrics = compute_generalization_metrics(y, pred, y, pred, targets)
+    for key in ("rmse_train", "rmse_test", "gap_pct", "gen_ratio"):
+        assert key in metrics["E_residual"]
+
+
+def test_compute_generalization_metrics_gen_ratio_one_for_identical_splits():
+    targets = ["t"]
+    y = pd.DataFrame({"t": [1.0, 2.0, 3.0, 4.0]})
+    pred = pd.DataFrame({"t": [1.5, 2.5, 3.5, 4.5]})
+    metrics = compute_generalization_metrics(y, pred, y, pred, targets)
+    assert metrics["t"]["gen_ratio"] == pytest.approx(1.0)
+
+
+def test_compute_generalization_metrics_gap_pct_positive_when_test_worse():
+    targets = ["t"]
+    y_train = pd.DataFrame({"t": [1.0, 2.0, 3.0]})
+    pred_train = pd.DataFrame({"t": [1.1, 2.1, 3.1]})  # small error
+    y_test = pd.DataFrame({"t": [1.0, 2.0, 3.0]})
+    pred_test = pd.DataFrame({"t": [2.0, 3.0, 4.0]})  # large error
+    metrics = compute_generalization_metrics(y_train, pred_train, y_test, pred_test, targets)
+    assert metrics["t"]["gap_pct"] > 0
+
+
+def test_compute_generalization_metrics_zero_train_rmse_handled():
+    """When train RMSE is zero, gap_pct and gen_ratio should handle division gracefully."""
+    targets = ["t"]
+    y = pd.DataFrame({"t": [1.0, 2.0]})
+    pred_perfect = pd.DataFrame({"t": [1.0, 2.0]})
+    pred_bad = pd.DataFrame({"t": [2.0, 3.0]})
+    metrics = compute_generalization_metrics(y, pred_perfect, y, pred_bad, targets)
+    assert metrics["t"]["rmse_train"] == pytest.approx(0.0)
+    assert np.isinf(metrics["t"]["gap_pct"]) or metrics["t"]["gap_pct"] > 0

--- a/tests/test_diagnostic_utils_full.py
+++ b/tests/test_diagnostic_utils_full.py
@@ -1,0 +1,161 @@
+"""Tests for remaining diagnostic_utils functions."""
+
+from unittest.mock import MagicMock
+
+import joblib
+import numpy as np
+import pandas as pd
+import pytest
+
+from eventdisplay_ml import diagnostic_utils
+
+
+@pytest.fixture
+def diagnostic_model_file(tmp_path):
+    path = tmp_path / "model.joblib"
+    joblib.dump(
+        {
+            "models": {
+                "xgboost": {
+                    "model": "cached-model",
+                    "features": ["f1", "f2"],
+                    "shap_importance": {"Xoff_residual": np.array([0.3, 0.7])},
+                    "generalization_metrics": {"Xoff_residual": {"rmse_train": 0.1}},
+                    "residual_normality_stats": {"Xoff_residual": {"mean": 0.0, "std": 1.0}},
+                    "shap_explainer": "explainer",
+                }
+            },
+            "features": ["f1", "f2"],
+            "target_mean": {"Xoff_residual": 1.0, "Yoff_residual": -1.0},
+            "target_std": {"Xoff_residual": 2.0, "Yoff_residual": 0.5},
+            "targets": ["Xoff_residual", "Yoff_residual"],
+            "input_file_list": "inputs.txt",
+            "train_test_fraction": 0.5,
+            "random_state": 3,
+        },
+        path,
+    )
+    return path
+
+
+@pytest.fixture
+def residual_frames():
+    y_test = pd.DataFrame(
+        {"Xoff_residual": [0.0, 0.5, 1.0, 1.5], "Yoff_residual": [1.0, 1.5, 2.0, 2.5]}
+    )
+    y_pred = pd.DataFrame(
+        {"Xoff_residual": [0.1, 0.4, 0.9, 1.4], "Yoff_residual": [0.8, 1.4, 2.2, 2.4]}
+    )
+    return y_test, y_pred
+
+
+def test_load_model_cfg_returns_first_model(diagnostic_model_file):
+    model_dict, model_cfg = diagnostic_utils._load_model_cfg(diagnostic_model_file)
+    assert model_cfg["features"] == ["f1", "f2"]
+    assert model_dict["target_mean"]["Xoff_residual"] == pytest.approx(1.0)
+
+
+def test_load_stereo_regression_split_reconstructs_split(monkeypatch, diagnostic_model_file):
+    df = pd.DataFrame(
+        {
+            "f1": np.arange(6, dtype=float),
+            "f2": np.arange(6, dtype=float) + 1.0,
+            "Xoff_residual": np.linspace(0.0, 0.5, 6),
+            "Yoff_residual": np.linspace(1.0, 1.5, 6),
+        }
+    )
+    monkeypatch.setattr(diagnostic_utils, "load_training_data", lambda *_: df)
+
+    model, x_train, y_train, x_test, y_test, features, targets, model_dict = (
+        diagnostic_utils.load_stereo_regression_split(diagnostic_model_file)
+    )
+
+    assert model == "cached-model"
+    assert len(x_train) == 3
+    assert len(x_test) == 3
+    assert features == ["f1", "f2"]
+    assert targets == ["Xoff_residual", "Yoff_residual"]
+    assert model_dict["random_state"] == 3
+    assert list(y_train.columns) == targets
+    assert list(y_test.columns) == targets
+
+
+def test_predict_unscaled_residuals_inverse_transforms_predictions():
+    model = MagicMock()
+    model.predict.return_value = np.array([[0.5, -2.0], [1.0, 0.0]])
+    x_data = pd.DataFrame({"f1": [0.0, 1.0]})
+    model_dict = {"target_mean": {"a": 1.0, "b": -1.0}, "target_std": {"a": 2.0, "b": 0.5}}
+
+    result = diagnostic_utils.predict_unscaled_residuals(model, x_data, model_dict, ["a", "b"])
+
+    assert result.loc[0, "a"] == pytest.approx(2.0)
+    assert result.loc[1, "b"] == pytest.approx(-1.0)
+
+
+def test_predict_unscaled_residuals_requires_scalers():
+    model = MagicMock()
+    model.predict.return_value = np.array([[0.0]])
+    with pytest.raises(ValueError, match="Missing target standardization"):
+        diagnostic_utils.predict_unscaled_residuals(model, pd.DataFrame({"f1": [0.0]}), {}, ["a"])
+
+
+def test_compute_residual_normality_stats_returns_summary(residual_frames):
+    y_test, y_pred = residual_frames
+    stats = diagnostic_utils.compute_residual_normality_stats(y_test, y_pred, ["Xoff_residual"])
+    assert stats["Xoff_residual"]["mean"] == pytest.approx(0.05)
+    assert stats["Xoff_residual"]["n_samples"] == 4
+    assert 0.0 <= stats["Xoff_residual"]["qq_r2"] <= 1.0
+
+
+def test_compute_residual_normality_stats_skips_all_nan_target():
+    y_test = pd.DataFrame({"target": [np.nan, np.nan]})
+    y_pred = pd.DataFrame({"target": [0.0, 1.0]})
+    assert diagnostic_utils.compute_residual_normality_stats(y_test, y_pred, ["target"]) == {}
+
+
+def test_load_cached_metrics_and_normality_stats(diagnostic_model_file):
+    _, metrics = diagnostic_utils.load_cached_generalization_metrics(diagnostic_model_file)
+    _, normality = diagnostic_utils.load_cached_residual_normality_stats(diagnostic_model_file)
+    assert metrics["Xoff_residual"]["rmse_train"] == pytest.approx(0.1)
+    assert normality["Xoff_residual"]["std"] == pytest.approx(1.0)
+
+
+def test_cached_loaders_return_none_for_missing_payloads(tmp_path):
+    path = tmp_path / "empty.joblib"
+    joblib.dump({"models": {"xgboost": {}}}, path)
+    assert diagnostic_utils.load_cached_generalization_metrics(path)[1] is None
+    assert diagnostic_utils.load_cached_residual_normality_stats(path)[1] is None
+
+
+def test_load_model_and_importance_supports_dict_and_legacy_formats(tmp_path):
+    dict_path = tmp_path / "dict.joblib"
+    legacy_path = tmp_path / "legacy.joblib"
+    joblib.dump(
+        {"models": {"xgboost": {"features": ["f1", "f2"], "shap_importance": {"t": [0.2, 0.8]}}}},
+        dict_path,
+    )
+    joblib.dump(
+        {"models": {"xgboost": {"features": ["f1", "f2"], "feature_importances": [0.4, 0.6]}}},
+        legacy_path,
+    )
+
+    assert diagnostic_utils.load_model_and_importance(dict_path, "t")[1]["f2"] == pytest.approx(0.8)
+    assert diagnostic_utils.load_model_and_importance(legacy_path)[1]["f1"] == pytest.approx(0.4)
+    assert diagnostic_utils.load_model_and_importance(dict_path, "missing")[1] is None
+
+
+def test_get_cached_shap_explainer_and_importance_dataframe(diagnostic_model_file):
+    df = diagnostic_utils.importance_dataframe(
+        diagnostic_model_file, top_n=1, target_name="Xoff_residual"
+    )
+    assert diagnostic_utils.get_cached_shap_explainer(diagnostic_model_file) == "explainer"
+    assert list(df["Feature"]) == ["f2"]
+    assert df.iloc[0]["Importance"] == pytest.approx(0.7)
+
+
+def test_validate_cached_data_summarizes_contents(diagnostic_model_file):
+    summary = diagnostic_utils.validate_cached_data(diagnostic_model_file)
+    assert summary["has_model"] is True
+    assert summary["has_shap_importance"] is True
+    assert summary["n_targets_with_shap"] == 1
+    assert summary["n_importances_per_target"]["Xoff_residual"] == 2

--- a/tests/test_evaluate_helpers.py
+++ b/tests/test_evaluate_helpers.py
@@ -1,0 +1,195 @@
+"""Unit tests for the pure-python helper functions in evaluate.py."""
+
+from unittest.mock import MagicMock
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from eventdisplay_ml.evaluate import (
+    _efficiency_dataframe,
+    _log_importance_table,
+    evaluation_efficiency,
+    feature_importance,
+    target_variance,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def binary_labels():
+    """Return a simple y_test array with balanced classes."""
+    rng = np.random.default_rng(42)
+    return rng.integers(0, 2, size=200)
+
+
+@pytest.fixture
+def mock_classifier():
+    """Mock model that returns deterministic probabilities."""
+    model = MagicMock()
+    rng = np.random.default_rng(0)
+    proba = rng.uniform(0, 1, size=(200, 2))
+    proba[:, 1] = proba[:, 0]  # column 1 is the "positive" probability
+    proba[:, 0] = 1 - proba[:, 1]
+    model.predict_proba.return_value = proba
+    return model
+
+
+# ---------------------------------------------------------------------------
+# _efficiency_dataframe
+# ---------------------------------------------------------------------------
+
+
+def test_efficiency_dataframe_shape(binary_labels):
+    thresholds = np.linspace(0, 1, 11)
+    proba = np.random.default_rng(1).uniform(0, 1, len(binary_labels))
+    df = _efficiency_dataframe("test", proba, binary_labels, thresholds)
+    assert len(df) == len(thresholds)
+    for col in (
+        "threshold",
+        "signal_efficiency",
+        "background_efficiency",
+        "n_signal",
+        "n_background",
+    ):
+        assert col in df.columns
+
+
+def test_efficiency_dataframe_threshold_zero_gives_full_efficiency(binary_labels):
+    proba = np.ones(len(binary_labels))
+    thresholds = np.array([0.0, 1.0])
+    df = _efficiency_dataframe("test", proba, binary_labels, thresholds)
+    assert df.iloc[0]["signal_efficiency"] == pytest.approx(1.0)
+    assert df.iloc[0]["background_efficiency"] == pytest.approx(1.0)
+
+
+def test_efficiency_dataframe_threshold_one_gives_zero_efficiency(binary_labels):
+    proba = np.zeros(len(binary_labels))
+    thresholds = np.array([0.0, 1.0])
+    df = _efficiency_dataframe("test", proba, binary_labels, thresholds)
+    # All predictions are 0, threshold=1.0 → none pass
+    assert df.iloc[1]["signal_efficiency"] == pytest.approx(0.0)
+    assert df.iloc[1]["background_efficiency"] == pytest.approx(0.0)
+
+
+def test_efficiency_dataframe_no_signal_returns_zero():
+    y_test = np.zeros(10, dtype=int)  # all background
+    proba = np.ones(10)
+    thresholds = np.array([0.5])
+    df = _efficiency_dataframe("test", proba, y_test, thresholds)
+    assert df.iloc[0]["signal_efficiency"] == pytest.approx(0.0)
+
+
+def test_efficiency_dataframe_values_in_unit_interval(binary_labels):
+    proba = np.random.default_rng(99).uniform(0, 1, len(binary_labels))
+    thresholds = np.linspace(0, 1, 21)
+    df = _efficiency_dataframe("test", proba, binary_labels, thresholds)
+    assert (df["signal_efficiency"] >= 0).all()
+    assert (df["signal_efficiency"] <= 1).all()
+    assert (df["background_efficiency"] >= 0).all()
+    assert (df["background_efficiency"] <= 1).all()
+
+
+# ---------------------------------------------------------------------------
+# target_variance
+# ---------------------------------------------------------------------------
+
+
+def test_target_variance_perfect_prediction_logs_zero_unexplained(caplog):
+    y_test = pd.DataFrame({"target_a": [1.0, 2.0, 3.0, 4.0]})
+    y_pred = y_test.to_numpy()
+    import logging
+
+    with caplog.at_level(logging.INFO):
+        target_variance(y_test, y_pred, ["target_a"])
+    # 0.00% unexplained variance when predictions are perfect
+    assert "0.00%" in caplog.text
+
+
+def test_target_variance_constant_target_warns(caplog):
+    y_test = pd.DataFrame({"flat": [5.0, 5.0, 5.0]})
+    y_pred = np.array([[5.0], [5.0], [5.0]])
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        target_variance(y_test, y_pred, ["flat"])
+    assert "zero variance" in caplog.text.lower()
+
+
+def test_target_variance_accepts_numpy_y_test():
+    y_test = np.array([[1.0, 2.0], [2.0, 3.0], [3.0, 4.0]])
+    y_pred = y_test + 0.1
+    # Should not raise
+    target_variance(y_test, y_pred, ["t1", "t2"])
+
+
+# ---------------------------------------------------------------------------
+# evaluation_efficiency (uses mock model)
+# ---------------------------------------------------------------------------
+
+
+def test_evaluation_efficiency_returns_dataframe(mock_classifier, binary_labels):
+    x_test = pd.DataFrame({"f1": range(200), "f2": range(200)})
+    y_test = pd.Series(binary_labels)
+    result = evaluation_efficiency("test", mock_classifier, x_test, y_test)
+    assert isinstance(result, pd.DataFrame)
+    assert "signal_efficiency" in result.columns
+    assert len(result) == 101  # 101 thresholds from linspace(0,1,101)
+
+
+def test_evaluation_efficiency_by_zenith_returns_tuple(mock_classifier, binary_labels):
+    rng = np.random.default_rng(7)
+    x_test = pd.DataFrame(
+        {
+            "f1": range(200),
+            "ze_bin": rng.integers(0, 3, size=200),
+        }
+    )
+    y_test = pd.Series(binary_labels)
+    result_all, result_by_ze = evaluation_efficiency(
+        "test", mock_classifier, x_test, y_test, return_by_zenith=True
+    )
+    assert isinstance(result_all, pd.DataFrame)
+    assert isinstance(result_by_ze, dict)
+
+
+def test_evaluation_efficiency_missing_ze_bin_returns_all_df(mock_classifier, binary_labels):
+    x_test = pd.DataFrame({"f1": range(200)})
+    y_test = pd.Series(binary_labels)
+    result_all, result_by_ze = evaluation_efficiency(
+        "test", mock_classifier, x_test, y_test, return_by_zenith=True
+    )
+    assert isinstance(result_all, pd.DataFrame)
+    assert result_by_ze == {}
+
+
+# ---------------------------------------------------------------------------
+# feature_importance (logging only; validate no crash)
+# ---------------------------------------------------------------------------
+
+
+def test_feature_importance_multioutput_no_crash():
+    model = MagicMock()
+    est1 = MagicMock()
+    est2 = MagicMock()
+    est1.feature_importances_ = np.array([0.5, 0.3, 0.2])
+    est2.feature_importances_ = np.array([0.1, 0.6, 0.3])
+    model.estimators_ = [est1, est2]
+    # Should not raise
+    feature_importance(model, ["f1", "f2", "f3"], ["target1", "target2"])
+
+
+def test_feature_importance_single_output_no_crash():
+    model = MagicMock(spec=["feature_importances_"])
+    model.feature_importances_ = np.array([0.4, 0.3, 0.3])
+    # Should not raise
+    feature_importance(model, ["f1", "f2", "f3"], ["label"])
+
+
+def test_log_importance_table_no_crash():
+    _log_importance_table(
+        "my_target", np.array([0.5, 0.3, 0.2]), ["feat_a", "feat_b", "feat_c"], "xgboost"
+    )

--- a/tests/test_evaluate_remaining.py
+++ b/tests/test_evaluate_remaining.py
@@ -1,0 +1,113 @@
+"""Tests for remaining evaluate.py branches (ze_bin, SHAP by energy)."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import numpy as np
+import pandas as pd
+import pytest
+import xgboost as xgb
+
+from eventdisplay_ml import evaluate
+
+
+@pytest.fixture
+def proba_model():
+    model = MagicMock()
+    model.predict_proba.return_value = np.column_stack([np.full(20, 0.3), np.full(20, 0.7)])
+    return model
+
+
+def test_evaluation_efficiency_returns_empty_dict_without_ze_bin(proba_model):
+    x_test = pd.DataFrame({"f1": np.ones(20)})
+    y_test = pd.Series([1, 0] * 10)
+    efficiency_all, efficiencies_by_zenith = evaluate.evaluation_efficiency(
+        "test", proba_model, x_test, y_test, return_by_zenith=True
+    )
+    assert len(efficiency_all) == 101
+    assert efficiencies_by_zenith == {}
+
+
+def test_evaluation_efficiency_groups_by_zenith(proba_model):
+    x_test = pd.DataFrame({"f1": np.ones(20), "ze_bin": [0] * 10 + [1] * 10})
+    y_test = pd.Series([1, 0] * 10)
+    _, efficiencies_by_zenith = evaluate.evaluation_efficiency(
+        "test", proba_model, x_test, y_test, return_by_zenith=True
+    )
+    assert sorted(efficiencies_by_zenith) == [0, 1]
+    assert len(efficiencies_by_zenith[0]) == 101
+
+
+def test_feature_importance_logs_joint_message(caplog):
+    model = SimpleNamespace(feature_importances_=np.array([0.2, 0.8]))
+    with caplog.at_level("INFO"):
+        evaluate.feature_importance(model, ["f1", "f2"], ["a", "b"], name="xgboost")
+    assert "JOINT importance" in caplog.text
+
+
+def test_evaluate_regression_model_runs_shap_per_energy(monkeypatch):
+    rng = np.random.default_rng(5)
+    x_train = pd.DataFrame({"f1": rng.standard_normal(40), "f2": rng.standard_normal(40)})
+    y_train = pd.DataFrame({"target": 0.5 * x_train["f1"] - 0.2 * x_train["f2"]})
+    model = xgb.XGBRegressor(n_estimators=5, max_depth=2, random_state=42)
+    model.fit(x_train, y_train)
+    x_test = x_train.iloc[:20].reset_index(drop=True)
+    y_test = y_train.iloc[:20].reset_index(drop=True)
+    y_pred = y_test.copy()
+    df = pd.DataFrame(
+        {
+            "MCe0": np.linspace(-1.0, 1.0, 20),
+            "Xoff_weighted_bdt": np.zeros(20),
+            "Yoff_weighted_bdt": np.zeros(20),
+            "ErecS": np.ones(20),
+        }
+    )
+    called = {"value": False}
+
+    def fake_resolution(*_args, **_kwargs):
+        called["value"] = True
+
+    class FakeCutResult:
+        def __init__(self, codes):
+            self.cat = type("CatAccessor", (), {"codes": np.asarray(codes, dtype=int)})()
+
+    monkeypatch.setattr(evaluate, "calculate_resolution", fake_resolution)
+    monkeypatch.setattr(
+        evaluate, "shap_feature_importance", lambda *_: {"target": np.array([0.2, 0.8])}
+    )
+    monkeypatch.setattr(evaluate.pd, "cut", lambda values, **_: FakeCutResult([0] * 10 + [1] * 10))
+
+    result = evaluate.evaluate_regression_model(
+        model,
+        x_test,
+        y_pred,
+        y_test,
+        df,
+        ["f1", "f2"],
+        y_test,
+        "xgboost",
+        shap_per_energy=True,
+    )
+
+    assert "target" in result
+    assert called["value"] is True
+
+
+def test_shap_feature_importance_by_energy_handles_real_xgboost(monkeypatch):
+    rng = np.random.default_rng(42)
+    x_train = pd.DataFrame({"f1": rng.standard_normal(50), "f2": rng.standard_normal(50)})
+    y_train = pd.DataFrame({"target": x_train["f1"] + 0.1 * x_train["f2"]})
+    model = xgb.XGBRegressor(n_estimators=5, max_depth=2, random_state=42)
+    model.fit(x_train, y_train)
+    x_test = x_train.iloc[:25].reset_index(drop=True)
+    y_test = y_train.iloc[:25].reset_index(drop=True)
+    df = pd.DataFrame({"MCe0": np.linspace(-1.0, 1.0, 25)})
+
+    class FakeCutResult:
+        def __init__(self, codes):
+            self.cat = type("CatAccessor", (), {"codes": np.asarray(codes, dtype=int)})()
+
+    monkeypatch.setattr(
+        evaluate.pd, "cut", lambda values, **_: FakeCutResult(([0] * 12) + ([1] * 13))
+    )
+    evaluate.shap_feature_importance_by_energy(model, x_test, df, y_test, ["target"])

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,0 +1,208 @@
+"""Unit tests for features.py."""
+
+import pytest
+
+from eventdisplay_ml.features import (
+    clip_intervals,
+    excluded_features,
+    features,
+    features_tmva_style,
+    target_features,
+    telescope_features,
+)
+
+# ---------------------------------------------------------------------------
+# target_features
+# ---------------------------------------------------------------------------
+
+
+def test_target_features_stereo_returns_three_residuals():
+    result = target_features("stereo_analysis")
+    assert result == ["Xoff_residual", "Yoff_residual", "E_residual"]
+
+
+def test_target_features_classification_returns_empty():
+    assert target_features("classification") == []
+
+
+def test_target_features_unknown_raises():
+    with pytest.raises(ValueError, match="Unknown analysis type"):
+        target_features("unknown_type")
+
+
+# ---------------------------------------------------------------------------
+# excluded_features
+# ---------------------------------------------------------------------------
+
+
+def test_excluded_features_stereo_contains_pointing_corrections():
+    result = excluded_features("stereo_analysis", ntel=2)
+    assert "fpointing_dx_0" in result
+    assert "fpointing_dx_1" in result
+    assert "fpointing_dy_0" in result
+    assert "fpointing_dy_1" in result
+
+
+def test_excluded_features_stereo_scales_with_ntel():
+    result2 = excluded_features("stereo_analysis", ntel=2)
+    result4 = excluded_features("stereo_analysis", ntel=4)
+    assert len(result4) > len(result2)
+    assert "fpointing_dx_3" in result4
+    assert "fpointing_dx_3" not in result2
+
+
+def test_excluded_features_classification_contains_energy_and_position():
+    result = excluded_features("classification", ntel=2)
+    assert "Erec" in result
+    assert "size_0" in result
+    assert "cen_x_0" in result
+    assert "cen_y_0" in result
+    assert "E_0" in result
+    assert "ES_0" in result
+
+
+def test_excluded_features_classification_returns_set():
+    result = excluded_features("classification", ntel=2)
+    assert isinstance(result, set)
+
+
+def test_excluded_features_unknown_raises():
+    with pytest.raises(ValueError, match="Unknown analysis type"):
+        excluded_features("mystery", ntel=4)
+
+
+# ---------------------------------------------------------------------------
+# telescope_features
+# ---------------------------------------------------------------------------
+
+
+def test_telescope_features_classification_excludes_disp_vars():
+    result = telescope_features("classification")
+    assert "Disp_T" not in result
+    assert "DispXoff_T" not in result
+    assert "size" in result
+
+
+def test_telescope_features_stereo_includes_disp_vars():
+    result = telescope_features("stereo_analysis")
+    assert "Disp_T" in result
+    assert "DispXoff_T" in result
+    assert "DispYoff_T" in result
+    assert "cen_x" in result
+    assert "E" in result
+
+
+def test_telescope_features_stereo_is_superset_of_classification():
+    stereo = set(telescope_features("stereo_analysis"))
+    cls = set(telescope_features("classification"))
+    assert cls.issubset(stereo)
+
+
+# ---------------------------------------------------------------------------
+# features / _regression_features / _classification_features
+# ---------------------------------------------------------------------------
+
+
+def test_features_stereo_training_includes_mc_truth():
+    result = features("stereo_analysis", training=True)
+    assert "MCxoff" in result
+    assert "MCyoff" in result
+    assert "MCe0" in result
+
+
+def test_features_stereo_inference_excludes_mc_truth():
+    result = features("stereo_analysis", training=False)
+    assert "MCxoff" not in result
+    assert "MCyoff" not in result
+    assert "MCe0" not in result
+
+
+def test_features_stereo_both_have_standard_branches():
+    for training in (True, False):
+        result = features("stereo_analysis", training=training)
+        assert "Erec" in result
+        assert "ErecS" in result
+        assert "EmissionHeight" in result
+        assert "DispNImages" in result
+
+
+def test_features_classification_returns_list():
+    result = features("classification")
+    assert isinstance(result, list)
+    assert len(result) > 0
+
+
+def test_features_classification_contains_mscw_mscl():
+    result = features("classification")
+    assert "MSCW" in result
+    assert "MSCL" in result
+
+
+def test_features_unknown_raises():
+    with pytest.raises(ValueError, match="Unknown analysis type"):
+        features("invalid_type")
+
+
+# ---------------------------------------------------------------------------
+# features_tmva_style
+# ---------------------------------------------------------------------------
+
+
+def test_features_tmva_style_classification_returns_list():
+    result = features_tmva_style("classification")
+    assert isinstance(result, list)
+    assert "MSCW" in result
+    assert "MSCL" in result
+    assert "EmissionHeight" in result
+
+
+def test_features_tmva_style_stereo_raises():
+    with pytest.raises(ValueError, match="TMVA-style"):
+        features_tmva_style("stereo_analysis")
+
+
+def test_features_tmva_style_unknown_raises():
+    with pytest.raises(ValueError, match="Unknown analysis type"):
+        features_tmva_style("bogus")
+
+
+# ---------------------------------------------------------------------------
+# clip_intervals
+# ---------------------------------------------------------------------------
+
+
+def test_clip_intervals_returns_dict():
+    result = clip_intervals()
+    assert isinstance(result, dict)
+
+
+def test_clip_intervals_key_variables_present():
+    result = clip_intervals()
+    for key in ("size", "Erec", "EmissionHeight", "MSCW", "MSCL", "tgrad_x"):
+        assert key in result, f"Expected '{key}' in clip_intervals"
+
+
+def test_clip_intervals_size_has_positive_lower_bound():
+    result = clip_intervals()
+    vmin, vmax = result["size"]
+    assert vmin == pytest.approx(1.0)
+    assert vmax is None
+
+
+def test_clip_intervals_emission_height_bounded():
+    result = clip_intervals()
+    vmin, vmax = result["EmissionHeight"]
+    assert vmin == pytest.approx(0.0)
+    assert vmax == pytest.approx(100.0)
+
+
+def test_clip_intervals_erec_has_lower_bound_only():
+    result = clip_intervals()
+    vmin, vmax = result["Erec"]
+    assert vmin > 0
+    assert vmax is None
+
+
+def test_clip_intervals_values_are_tuples_of_length_two():
+    for key, val in clip_intervals().items():
+        assert len(val) == 2, f"clip_intervals['{key}'] should be a 2-tuple"

--- a/tests/test_geomag.py
+++ b/tests/test_geomag.py
@@ -1,0 +1,139 @@
+"""Unit tests for geomag.py."""
+
+import numpy as np
+import pytest
+
+from eventdisplay_ml.geomag import FIELD_COMPONENTS, calculate_geomagnetic_angles
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _expected_angle(azimuth_deg, elevation_deg, observatory):
+    """Recompute the expected angle from scratch for verification."""
+    obs = observatory.upper()
+    bx = FIELD_COMPONENTS[obs]["BX"]
+    by = FIELD_COMPONENTS[obs]["BY"]
+    bz = FIELD_COMPONENTS[obs]["BZ"]
+
+    sx = np.cos(np.radians(elevation_deg)) * np.cos(np.radians(azimuth_deg))
+    sy = np.cos(np.radians(elevation_deg)) * np.sin(np.radians(azimuth_deg))
+    sz = np.sin(np.radians(elevation_deg))
+
+    b_mag = np.sqrt(bx**2 + by**2 + bz**2)
+    bx_n = bx / b_mag
+    by_n = by / b_mag
+    bz_n = -bz / b_mag  # sign flip as in source
+
+    cos_theta = sx * bx_n + sy * by_n + sz * bz_n
+    return np.degrees(np.arccos(np.clip(cos_theta, -1, 1)))
+
+
+# ---------------------------------------------------------------------------
+# Basic correctness tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("observatory", ["VERITAS", "CTAO-NORTH", "CTAO-SOUTH"])
+def test_angle_at_zenith_is_in_valid_range(observatory):
+    """Pointing straight up should give a valid angle for any observatory."""
+    angle = calculate_geomagnetic_angles(0.0, 90.0, observatory=observatory)
+    assert 0.0 <= float(angle) <= 180.0
+
+
+@pytest.mark.parametrize(("az", "el"), [(0, 90), (0, 45), (180, 45), (90, 0), (270, 30)])
+def test_angle_always_between_0_and_180(az, el):
+    angle = calculate_geomagnetic_angles(az, el)
+    assert 0.0 <= float(angle) <= 180.0
+
+
+def test_angle_matches_manual_computation_veritas():
+    az, el = 30.0, 60.0
+    expected = _expected_angle(az, el, "VERITAS")
+    result = calculate_geomagnetic_angles(az, el, observatory="VERITAS")
+    assert result == pytest.approx(expected, rel=1e-5)
+
+
+def test_angle_matches_manual_computation_ctao_north():
+    az, el = 120.0, 45.0
+    expected = _expected_angle(az, el, "CTAO-NORTH")
+    result = calculate_geomagnetic_angles(az, el, observatory="CTAO-NORTH")
+    assert result == pytest.approx(expected, rel=1e-5)
+
+
+def test_angle_matches_manual_computation_ctao_south():
+    az, el = 200.0, 30.0
+    expected = _expected_angle(az, el, "CTAO-SOUTH")
+    result = calculate_geomagnetic_angles(az, el, observatory="CTAO-SOUTH")
+    assert result == pytest.approx(expected, rel=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# Array-valued inputs
+# ---------------------------------------------------------------------------
+
+
+def test_accepts_numpy_arrays():
+    az = np.array([0.0, 90.0, 180.0, 270.0])
+    el = np.array([45.0, 45.0, 45.0, 45.0])
+    result = calculate_geomagnetic_angles(az, el)
+    assert result.shape == (4,)
+    assert np.all((result >= 0) & (result <= 180))
+
+
+def test_array_matches_scalar_results():
+    azimuths = [0.0, 30.0, 90.0]
+    elevations = [45.0, 60.0, 30.0]
+    scalar_results = [
+        float(calculate_geomagnetic_angles(az, el)) for az, el in zip(azimuths, elevations)
+    ]
+    array_result = calculate_geomagnetic_angles(np.array(azimuths), np.array(elevations))
+    np.testing.assert_allclose(array_result, scalar_results, rtol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# Case-insensitivity and different observatories
+# ---------------------------------------------------------------------------
+
+
+def test_observatory_name_is_case_insensitive():
+    angle_upper = calculate_geomagnetic_angles(0.0, 45.0, observatory="VERITAS")
+    angle_lower = calculate_geomagnetic_angles(0.0, 45.0, observatory="veritas")
+    assert float(angle_upper) == pytest.approx(float(angle_lower))
+
+
+def test_different_observatories_give_different_angles():
+    """VERITAS and CTAO-SOUTH have different field components → different angles."""
+    az, el = 45.0, 45.0
+    angle_veritas = float(calculate_geomagnetic_angles(az, el, observatory="VERITAS"))
+    angle_ctao_south = float(calculate_geomagnetic_angles(az, el, observatory="CTAO-SOUTH"))
+    assert angle_veritas != pytest.approx(angle_ctao_south)
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_observatory_raises_key_error():
+    with pytest.raises(KeyError, match="not defined"):
+        calculate_geomagnetic_angles(0.0, 45.0, observatory="UNKNOWN_SITE")
+
+
+# ---------------------------------------------------------------------------
+# Physical consistency
+# ---------------------------------------------------------------------------
+
+
+def test_field_components_dict_has_required_keys():
+    for obs in ("VERITAS", "CTAO-NORTH", "CTAO-SOUTH"):
+        assert obs in FIELD_COMPONENTS
+        for comp in ("BX", "BY", "BZ"):
+            assert comp in FIELD_COMPONENTS[obs]
+
+
+def test_veritas_by_is_zero():
+    """BY is assumed 0 for all defined observatories (CORSIKA convention)."""
+    for obs in FIELD_COMPONENTS.values():
+        assert obs["BY"] == pytest.approx(0.0)

--- a/tests/test_hyper_parameters.py
+++ b/tests/test_hyper_parameters.py
@@ -60,11 +60,10 @@ def test_classification_hyper_parameters_has_expected_keys():
         assert key in hp
 
 
-def test_regression_returns_copy_not_same_object():
-    """Default dict should be returned as-is; mutations could affect defaults."""
+def test_regression_hyper_parameters_returns_same_default_dict_object():
+    """regression_hyper_parameters returns the module-level default dict (no defensive copy)."""
     r1 = regression_hyper_parameters()
     r2 = regression_hyper_parameters()
-    # Both calls should return the same default dict
     assert r1 is r2
 
 

--- a/tests/test_hyper_parameters.py
+++ b/tests/test_hyper_parameters.py
@@ -1,0 +1,158 @@
+"""Unit tests for hyper_parameters.py."""
+
+import json
+
+import pytest
+
+from eventdisplay_ml.hyper_parameters import (
+    PRE_CUTS_CLASSIFICATION,
+    classification_hyper_parameters,
+    hyper_parameters,
+    pre_cuts_classification,
+    pre_cuts_regression,
+    regression_hyper_parameters,
+)
+
+# ---------------------------------------------------------------------------
+# hyper_parameters dispatcher
+# ---------------------------------------------------------------------------
+
+
+def test_hyper_parameters_stereo_returns_regression_dict():
+    result = hyper_parameters("stereo_analysis")
+    assert "xgboost" in result
+    assert "hyper_parameters" in result["xgboost"]
+
+
+def test_hyper_parameters_classification_returns_classification_dict():
+    result = hyper_parameters("classification")
+    assert "xgboost" in result
+    hp = result["xgboost"]["hyper_parameters"]
+    assert hp["objective"] == "binary:logistic"
+
+
+def test_hyper_parameters_unknown_raises():
+    with pytest.raises(ValueError, match="Unknown analysis type"):
+        hyper_parameters("mystery")
+
+
+# ---------------------------------------------------------------------------
+# Default hyperparameter structures
+# ---------------------------------------------------------------------------
+
+
+def test_regression_hyper_parameters_has_expected_keys():
+    result = regression_hyper_parameters()
+    hp = result["xgboost"]["hyper_parameters"]
+    for key in ("n_estimators", "learning_rate", "max_depth", "objective"):
+        assert key in hp, f"Expected key '{key}' in regression hyperparameters"
+
+
+def test_regression_hyper_parameters_objective_is_squared_error():
+    hp = regression_hyper_parameters()["xgboost"]["hyper_parameters"]
+    assert hp["objective"] == "reg:squarederror"
+
+
+def test_classification_hyper_parameters_has_expected_keys():
+    result = classification_hyper_parameters()
+    hp = result["xgboost"]["hyper_parameters"]
+    for key in ("n_estimators", "learning_rate", "max_depth", "objective"):
+        assert key in hp
+
+
+def test_regression_returns_copy_not_same_object():
+    """Default dict should be returned as-is; mutations could affect defaults."""
+    r1 = regression_hyper_parameters()
+    r2 = regression_hyper_parameters()
+    # Both calls should return the same default dict
+    assert r1 is r2
+
+
+# ---------------------------------------------------------------------------
+# Load from file
+# ---------------------------------------------------------------------------
+
+
+def test_regression_hyper_parameters_from_file(tmp_path):
+    custom = {
+        "custom_model": {
+            "model": None,
+            "hyper_parameters": {"n_estimators": 100, "max_depth": 3},
+        }
+    }
+    f = tmp_path / "hp.json"
+    f.write_text(json.dumps(custom))
+    result = regression_hyper_parameters(config_file=str(f))
+    assert result == custom
+
+
+def test_classification_hyper_parameters_from_file(tmp_path):
+    custom = {"xgboost": {"model": None, "hyper_parameters": {"n_estimators": 50}}}
+    f = tmp_path / "hp.json"
+    f.write_text(json.dumps(custom))
+    result = classification_hyper_parameters(config_file=str(f))
+    assert result["xgboost"]["hyper_parameters"]["n_estimators"] == 50
+
+
+# ---------------------------------------------------------------------------
+# pre_cuts_regression
+# ---------------------------------------------------------------------------
+
+
+def test_pre_cuts_regression_default_min_images():
+    result = pre_cuts_regression()
+    assert "DispNImages >=2" in result
+
+
+def test_pre_cuts_regression_custom_min_images():
+    result = pre_cuts_regression(min_images=3)
+    assert "DispNImages >=3" in result
+
+
+def test_pre_cuts_regression_returns_string():
+    result = pre_cuts_regression()
+    assert isinstance(result, str)
+
+
+def test_pre_cuts_regression_no_extra_cuts_when_list_empty():
+    """PRE_CUTS_REGRESSION is empty by default; result contains only DispNImages cut."""
+    result = pre_cuts_regression()
+    # Should be a simple expression, not empty
+    assert result is not None
+    assert len(result) > 0
+
+
+# ---------------------------------------------------------------------------
+# pre_cuts_classification
+# ---------------------------------------------------------------------------
+
+
+def test_pre_cuts_classification_contains_energy_bounds():
+    result = pre_cuts_classification(e_min=0.1, e_max=100.0)
+    assert "0.1" in result
+    assert "100.0" in result
+    assert "Erec" in result
+
+
+def test_pre_cuts_classification_includes_mscw_cut():
+    result = pre_cuts_classification(e_min=0.1, e_max=10.0)
+    assert "MSCW" in result
+
+
+def test_pre_cuts_classification_includes_emission_height_cut():
+    result = pre_cuts_classification(e_min=0.1, e_max=10.0)
+    assert "EmissionHeight" in result
+
+
+def test_pre_cuts_classification_returns_string():
+    result = pre_cuts_classification(e_min=0.01, e_max=1000.0)
+    assert isinstance(result, str)
+
+
+@pytest.mark.parametrize("cut", PRE_CUTS_CLASSIFICATION)
+def test_pre_cuts_classification_includes_all_default_cuts(cut):
+    """Each default quality cut should appear in the combined cut string."""
+    result = pre_cuts_classification(e_min=0.1, e_max=10.0)
+    # Cuts are wrapped in parentheses but variable names are preserved
+    var = cut.split()[0]
+    assert var in result

--- a/tests/test_models_helpers.py
+++ b/tests/test_models_helpers.py
@@ -1,0 +1,247 @@
+"""Tests for models.py helper functions, loaders, and training routines."""
+
+from unittest.mock import MagicMock, patch
+
+import joblib
+import numpy as np
+import pandas as pd
+import pytest
+
+from eventdisplay_ml import features, models
+
+
+@pytest.fixture
+def regression_model_file(tmp_path):
+    path = tmp_path / "regression.joblib"
+    joblib.dump(
+        {
+            "models": {"xgboost": {"model": "reg-model"}},
+            "features": ["f1", "f2"],
+            "target_mean": {"Xoff_residual": 0.0},
+        },
+        path,
+    )
+    return path
+
+
+@pytest.fixture
+def classification_prefix(tmp_path):
+    prefix = tmp_path / "model"
+    efficiency = pd.DataFrame(
+        {
+            "signal_efficiency": np.linspace(0.0, 1.0, 101),
+            "background_efficiency": np.linspace(1.0, 0.0, 101),
+            "threshold": np.linspace(1.0, 0.0, 101),
+        }
+    )
+    for ebin in (0, 1):
+        suffix = ".joblib.gz" if ebin == 1 else ".joblib"
+        joblib.dump(
+            {
+                "models": {"xgboost": {"model": f"clf-{ebin}", "efficiency": efficiency}},
+                "features": ["f1"],
+                "energy_bins_log10_tev": {"E_min": float(ebin), "E_max": float(ebin + 1)},
+                "zenith_bins_deg": [{"Ze_min": 0, "Ze_max": 20}],
+                "energy_bin_number": ebin,
+            },
+            tmp_path / f"model_ebin{ebin}{suffix}",
+        )
+    return prefix
+
+
+def test_save_models_writes_expected_joblib(tmp_path):
+    model_configs = {"model_prefix": str(tmp_path / "saved"), "models": {"xgboost": {}}}
+    models.save_models(model_configs)
+    assert (tmp_path / "saved.joblib.gz").exists()
+
+
+def test_load_models_dispatches_and_rejects_unknown(monkeypatch):
+    monkeypatch.setattr(models, "load_regression_models", lambda *args: ("reg", args))
+    monkeypatch.setattr(models, "load_classification_models", lambda *args: ("clf", args))
+    assert models.load_models("stereo_analysis", "m", "n")[0] == "reg"
+    assert models.load_models("classification", "m", "n")[0] == "clf"
+    with pytest.raises(ValueError, match="Unknown analysis_type"):
+        models.load_models("bad", "m", "n")
+
+
+def test_load_classification_models_collects_bins_and_thresholds(classification_prefix):
+    loaded, par = models.load_classification_models(str(classification_prefix), "xgboost")
+    assert sorted(loaded) == [0, 1]
+    assert loaded[0]["thresholds"][20] == pytest.approx(0.8)
+    assert par["energy_bins_log10_tev"][1]["E_max"] == pytest.approx(2.0)
+
+
+def test_classification_thresholds_and_parameter_updates():
+    efficiency = pd.DataFrame({"signal_efficiency": [0.2, 0.4, 0.6], "threshold": [0.9, 0.5, 0.1]})
+    thresholds = models._calculate_classification_thresholds(
+        efficiency, min_efficiency=0.2, steps=20
+    )
+    updated = models._update_parameters(
+        {}, [{"Ze_min": 0, "Ze_max": 20}], {"E_min": -1.0, "E_max": 1.0}, 0
+    )
+    assert thresholds[20] == pytest.approx(0.9)
+    assert updated["energy_bins_log10_tev"][0]["E_min"] == pytest.approx(-1.0)
+    with pytest.raises(ValueError, match="Inconsistent zenith_bins_deg"):
+        models._update_parameters(updated, [], {"E_min": 0.0, "E_max": 1.0}, 1)
+
+
+def test_check_bin_and_load_regression_models(regression_model_file):
+    with pytest.raises(ValueError, match="Bin number mismatch"):
+        models._check_bin(0, 1)
+    loaded, par = models.load_regression_models(str(regression_model_file), "xgboost")
+    assert loaded["xgboost"]["model"] == "reg-model"
+    assert par["target_mean"]["Xoff_residual"] == pytest.approx(0.0)
+    assert "target_std" not in par
+
+
+def test_output_tree_and_apply_model(monkeypatch):
+    root_file = MagicMock()
+    stereo_tree = MagicMock()
+    class_tree = MagicMock()
+    root_file.mktree.side_effect = [stereo_tree, class_tree]
+    models._output_tree("stereo_analysis", root_file)
+    models._output_tree("classification", root_file, [20])
+    monkeypatch.setattr(
+        models,
+        "apply_regression_models",
+        lambda *_: (np.array([1.0]), np.array([2.0]), np.array([1.0])),
+    )
+    monkeypatch.setattr(
+        models,
+        "apply_classification_models",
+        lambda *_: (np.array([0.8]), {20: np.array([1], dtype=np.uint8)}),
+    )
+
+    models._apply_model("stereo_analysis", pd.DataFrame({"a": [1]}), {}, stereo_tree)
+    models._apply_model("classification", pd.DataFrame({"a": [1]}), {}, class_tree, [20])
+
+    assert root_file.mktree.call_args_list[0].args[0] == "StereoAnalysis"
+    assert root_file.mktree.call_args_list[1].args[0] == "Classification"
+    assert stereo_tree.extend.call_args.args[0]["Dir_Erec"][0] == pytest.approx(10.0)
+    assert class_tree.extend.call_args.args[0]["Gamma_Prediction"][0] == pytest.approx(0.8)
+    with pytest.raises(ValueError, match="Unknown analysis_type"):
+        models._output_tree("bad", root_file)
+    with pytest.raises(ValueError, match="Unknown analysis_type"):
+        models._apply_model("bad", pd.DataFrame(), {}, stereo_tree)
+
+
+def test_train_regression_returns_none_for_empty_frame():
+    result = models.train_regression(pd.DataFrame(), {"targets": ["x"], "models": {}})
+    assert result is None
+
+
+def test_train_regression_trains_tiny_model(monkeypatch):
+    rng = np.random.default_rng(42)
+    n_rows = 60
+    df = pd.DataFrame(
+        {
+            "f1": rng.standard_normal(n_rows),
+            "f2": rng.standard_normal(n_rows),
+            "ErecS": rng.uniform(0.1, 10.0, n_rows),
+            "Xoff_weighted_bdt": rng.standard_normal(n_rows),
+            "Yoff_weighted_bdt": rng.standard_normal(n_rows),
+            "Xoff_residual": rng.standard_normal(n_rows) * 0.01,
+            "Yoff_residual": rng.standard_normal(n_rows) * 0.01,
+            "E_residual": rng.standard_normal(n_rows) * 0.01,
+            "DispNImages": rng.integers(2, 5, n_rows),
+        }
+    )
+    config = {
+        "targets": ["Xoff_residual", "Yoff_residual", "E_residual"],
+        "train_test_fraction": 0.5,
+        "random_state": 42,
+        "models": {
+            "test": {
+                "hyper_parameters": {
+                    "n_estimators": 5,
+                    "max_depth": 2,
+                    "learning_rate": 0.1,
+                    "random_state": 42,
+                    "early_stopping_rounds": 2,
+                }
+            }
+        },
+    }
+    monkeypatch.setattr(models, "evaluate_regression_model", lambda *args: {"ok": np.array([1.0])})
+
+    result = models.train_regression(df, config)
+
+    assert result["models"]["test"]["features"] == [
+        "f1",
+        "f2",
+        "ErecS",
+        "Xoff_weighted_bdt",
+        "Yoff_weighted_bdt",
+        "DispNImages",
+    ]
+    assert "generalization_metrics" in result["models"]["test"]
+    assert "residual_normality_stats" in result["models"]["test"]
+
+
+def test_train_classification_handles_empty_and_zenith_efficiencies(monkeypatch):
+    with pytest.raises(ValueError, match="requires non-empty"):
+        models.train_classification([pd.DataFrame(), pd.DataFrame({"f1": [1.0]})], {"models": {}})
+
+    rng = np.random.default_rng(7)
+    signal = pd.DataFrame(
+        {
+            "f1": rng.standard_normal(40),
+            "f2": rng.standard_normal(40) + 1.0,
+            "ze_bin": np.repeat([0, 1], 20),
+        }
+    )
+    background = pd.DataFrame(
+        {
+            "f1": rng.standard_normal(40),
+            "f2": rng.standard_normal(40) - 1.0,
+            "ze_bin": np.repeat([0, 1], 20),
+        }
+    )
+    config = {
+        "train_test_fraction": 0.5,
+        "random_state": 42,
+        "models": {
+            "test": {
+                "hyper_parameters": {
+                    "n_estimators": 5,
+                    "max_depth": 2,
+                    "learning_rate": 0.1,
+                    "random_state": 42,
+                    "eval_metric": "logloss",
+                }
+            }
+        },
+    }
+    monkeypatch.setattr(
+        models, "evaluate_classification_model", lambda *args: {"label": np.array([0.1, 0.9, 0.0])}
+    )
+
+    result = models.train_classification([signal, background], config)
+
+    assert "efficiency" in result["models"]["test"]
+    assert "efficiency_ze0" in result["models"]["test"]
+    assert result["models"]["test"]["features"] == ["f1", "f2", "ze_bin"]
+
+
+def test_process_file_chunked_uses_tmva_style_features_when_flag_set():
+    """Regression test for E5: classification with tmva_style=True must use features_tmva_style."""
+    tmva_features = features.features_tmva_style("classification", training=False)
+    expected = [b for b in tmva_features if b not in {"ze_bin", "ArrayPointing_Azimuth"}] + [
+        "ArrayPointing_Elevation"
+    ]
+    regular_features = features.features("classification", training=False)
+
+    def fake_open(path):
+        raise RuntimeError("uproot not needed for this assertion")
+
+    with patch("eventdisplay_ml.models.uproot.open", side_effect=fake_open):
+        with pytest.raises(RuntimeError, match="uproot not needed"):
+            models.process_file_chunked(
+                "classification",
+                {"tmva_style": True, "input_file": "dummy.root"},
+            )
+
+    # Verify that tmva_style features differ from regular features
+    assert set(expected) != set(regular_features)
+    assert "ArrayPointing_Elevation" in expected
+    assert "ze_bin" not in expected

--- a/tests/test_optimize_helpers.py
+++ b/tests/test_optimize_helpers.py
@@ -1,0 +1,203 @@
+"""Tests for pure helper functions in scripts/optimize_classification.py."""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import joblib
+import numpy as np
+import pandas as pd
+import pytest
+
+from eventdisplay_ml.scripts import optimize_classification as opt
+
+
+@pytest.fixture
+def efficiency_surface_inputs():
+    energy = np.array([0.0, 1.0, 0.0, 1.0], dtype=float)
+    zenith = np.array([0.0, 0.0, 60.0, 60.0], dtype=float)
+    values = np.array([1.0, 2.0, 3.0, 4.0], dtype=float)
+    return energy, zenith, values
+
+
+def test_validate_and_convert_zenith_helpers():
+    opt._validate_source_index(2.5)
+    assert opt._zenith_to_inverse_cosine(60.0) == pytest.approx(2.0)
+    with pytest.raises(ValueError, match=r"within \[2, 5\]"):
+        opt._validate_source_index(5.5)
+
+
+def test_build_uniform_axis_and_edges():
+    axis = opt._build_uniform_axis(0.0, 1.0, 0.4)
+    edges = opt._build_bin_edges_from_centers([1.0])
+    assert axis.tolist() == pytest.approx([0.0, 0.4, 0.8, 1.0])
+    assert edges.tolist() == pytest.approx([0.5, 1.5])
+    with pytest.raises(ValueError, match="positive"):
+        opt._build_uniform_axis(0.0, 1.0, 0.0)
+    with pytest.raises(ValueError, match="At least one bin center"):
+        opt._build_bin_edges_from_centers([])
+
+
+def test_reshape_surface_and_rate_interpolator(efficiency_surface_inputs):
+    energy, zenith, values = efficiency_surface_inputs
+    energy_axis, zenith_axis, surface = opt._reshape_surface(energy, zenith, values)
+    interpolator, _, _ = opt._build_rate_interpolator(energy, zenith, values)
+    sampled = opt._sample_rate_interpolator(interpolator, np.array([0.5]), np.array([60.0]))
+    assert energy_axis.tolist() == [0.0, 1.0]
+    assert zenith_axis.tolist() == [0.0, 60.0]
+    assert surface[1, 0] == pytest.approx(3.0)
+    assert sampled[0] == pytest.approx(3.5)
+    with pytest.raises(ValueError, match="rectangular grid"):
+        opt._reshape_surface([0.0, 1.0, 0.0], [0.0, 0.0, 60.0], [1.0, 2.0, 3.0])
+
+
+def _constant_bg(points):
+    return np.full(len(points), 0.5)
+
+
+def test_mesh_li_ma_and_cut_optimization():
+    log10_energy, zenith = opt._mesh_energy_zenith(np.array([0.0, 1.0]), np.array([0.0, 60.0]))
+    li_ma = opt._li_ma_significance(np.array([30.0]), np.array([60.0]), opt._ALPHA)
+    best = opt._optimize_cut_2d(
+        np.array([0.0]),
+        np.array([2.0]),
+        np.array([1.0]),
+        opt._ALPHA,
+        100.0,
+        np.array([0.2, 0.8]),
+        _constant_bg,
+    )
+    assert log10_energy.shape == zenith.shape == (4,)
+    assert li_ma[0] > 0
+    assert best.tolist() == [0.8]
+
+
+def _linear_interpolator(points):
+    return points[:, 0] + points[:, 1]
+
+
+def test_evaluate_efficiency_interpolator_and_model_zenith_centers():
+    values = opt._evaluate_efficiency_interpolator(_linear_interpolator, [2.0], [0.5], (0.0, 1.0))
+    centers = opt._model_zenith_bin_centers(
+        [{"Ze_min": 0, "Ze_max": 20}, {"Ze_min": 20, "Ze_max": 40}]
+    )
+    assert values[0] == pytest.approx(1.5)
+    assert centers.tolist() == pytest.approx([10.0, 30.0])
+    with pytest.raises(ValueError, match="No zenith binning"):
+        opt._model_zenith_bin_centers([])
+
+
+def test_extract_load_and_fill_rates(monkeypatch, efficiency_surface_inputs):
+    energy, zenith, values = efficiency_surface_inputs
+    graph = MagicMock()
+    graph.values.return_value = (energy, zenith, values)
+    root_handle = MagicMock()
+    root_handle.__enter__.return_value = {"gONRate": graph, "gBGRate": graph}
+    root_handle.__exit__.return_value = False
+    monkeypatch.setattr(opt.uproot, "open", lambda *_: root_handle)
+
+    loaded = opt._load_rates(Path("rates.root"))
+    filled = opt._fill_rate(
+        Path("rates.root"),
+        {0.5: (0.0, 1.0)},
+        [{"Ze_min": 0, "Ze_max": 20}],
+        source_strength=0.5,
+        source_index=opt._CRAB_INDEX,
+        energy_bin_width=0.5,
+        inverse_cosine_zenith_bin_width=0.5,
+    )
+
+    assert loaded[2].tolist() == values.tolist()
+    assert np.all(filled.signal_rate >= 0.0)
+    assert filled.model_energy_axis.tolist() == [0.5]
+
+
+def test_load_multi_bin_roc_and_main(tmp_path, monkeypatch):
+    efficiency = pd.DataFrame(
+        {
+            "signal_efficiency": [0.2, 0.8],
+            "background_efficiency": [0.1, 0.05],
+            "threshold": [0.8, 0.2],
+        }
+    )
+    roc_path = tmp_path / "roc_ebin0.joblib"
+    roc_path_1 = tmp_path / "roc_ebin1.joblib"
+    joblib.dump(
+        {
+            "energy_bins_log10_tev": {"E_min": -1.0, "E_max": 0.0},
+            "zenith_bins_deg": [{"Ze_min": 0, "Ze_max": 20}],
+            "models": {"xgboost": {"efficiency": efficiency}},
+        },
+        roc_path,
+    )
+    joblib.dump(
+        {
+            "energy_bins_log10_tev": {"E_min": 0.0, "E_max": 1.0},
+            "zenith_bins_deg": [{"Ze_min": 0, "Ze_max": 20}],
+            "models": {"xgboost": {"efficiency": efficiency}},
+        },
+        roc_path_1,
+    )
+    bg_interp, thresh_interp, energy_bins_map, zenith_bins_deg = opt._load_multi_bin_roc(
+        [str(roc_path), str(roc_path_1)]
+    )
+    assert energy_bins_map[-0.5] == (-1.0, 0.0)
+    assert zenith_bins_deg[0]["Ze_max"] == pytest.approx(20.0)
+    assert np.isfinite(bg_interp(np.array([[0.0, 0.5]])))[0]
+    assert np.isfinite(thresh_interp(np.array([[0.0, 0.5]])))[0]
+
+    rate_grid = opt.RateGrid(
+        log10_energy_tev=np.array([0.0]),
+        zenith_deg=np.array([10.0]),
+        on_rate=np.array([5.0]),
+        background_rate=np.array([2.0]),
+        signal_rate=np.array([3.0]),
+        energy_axis=np.array([0.0]),
+        zenith_axis=np.array([10.0]),
+        model_energy_axis=np.array([0.0]),
+        model_zenith_axis=np.array([10.0]),
+        model_log10_energy=np.array([0.0]),
+        model_zenith_deg=np.array([10.0]),
+        model_signal_rate=np.array([3.0]),
+        model_background_rate=np.array([2.0]),
+    )
+
+    class DummyTable(dict):
+        def __init__(self):
+            super().__init__()
+            self.meta = {}
+            self.output = None
+
+        def write(self, output, format=None, overwrite=False):  # noqa: A002
+            self.output = (output, format, overwrite)
+
+    monkeypatch.setattr(
+        opt,
+        "_load_multi_bin_roc",
+        lambda *_: (
+            lambda points: np.full(len(points), 0.2),
+            lambda points: np.full(len(points), 0.7),
+            {0.0: (-0.5, 0.5)},
+            [{"Ze_min": 0, "Ze_max": 20}],
+        ),
+    )
+    monkeypatch.setattr(opt, "_fill_rate", lambda *_: rate_grid)
+    monkeypatch.setattr(opt, "_optimize_cut_2d", lambda *_: np.array([0.6]))
+    monkeypatch.setattr(opt, "_interpolate_efficiency_surface", lambda *_: np.array([0.6]))
+    monkeypatch.setattr(opt, "_evaluate_efficiency_interpolator", lambda *_: np.array([0.2]))
+    monkeypatch.setattr(opt, "Table", DummyTable)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "prog",
+            "rates.root",
+            str(roc_path),
+            str(roc_path_1),
+            "1.0",
+            "--output",
+            str(tmp_path / "optimized.ecsv"),
+        ],
+    )
+
+    opt.main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -219,6 +219,6 @@ def test_output_file_name_creates_parent_directory(tmp_path):
     assert (tmp_path / "subdir").is_dir()
 
 
-def test_output_file_name_returns_path_object(tmp_path):
+def test_output_file_name_returns_string(tmp_path):
     result = output_file_name(tmp_path / "model")
     assert isinstance(result, str)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,224 @@
+"""Unit tests for utils.py."""
+
+import json
+
+import pytest
+
+from eventdisplay_ml.utils import (
+    load_energy_range,
+    load_model_parameters,
+    output_file_name,
+    parse_image_selection,
+    read_input_file_list,
+    resolve_joblib_path,
+)
+
+# ---------------------------------------------------------------------------
+# resolve_joblib_path
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_joblib_gz_found(tmp_path):
+    p = tmp_path / "model.joblib.gz"
+    p.touch()
+    assert resolve_joblib_path(p) == p
+
+
+def test_resolve_joblib_found_when_gz_missing(tmp_path):
+    p = tmp_path / "model.joblib"
+    p.touch()
+    result = resolve_joblib_path(tmp_path / "model.joblib")
+    assert result == p
+
+
+def test_resolve_prefix_finds_gz_first(tmp_path):
+    gz = tmp_path / "model.joblib.gz"
+    plain = tmp_path / "model.joblib"
+    gz.touch()
+    plain.touch()
+    result = resolve_joblib_path(tmp_path / "model")
+    assert result == gz
+
+
+def test_resolve_prefix_falls_back_to_joblib(tmp_path):
+    plain = tmp_path / "model.joblib"
+    plain.touch()
+    result = resolve_joblib_path(tmp_path / "model")
+    assert result == plain
+
+
+def test_resolve_missing_raises_file_not_found(tmp_path):
+    with pytest.raises(FileNotFoundError, match="Could not resolve"):
+        resolve_joblib_path(tmp_path / "nonexistent")
+
+
+def test_resolve_gz_suffix_tries_plain_fallback(tmp_path):
+    plain = tmp_path / "model.joblib"
+    plain.touch()
+    result = resolve_joblib_path(tmp_path / "model.joblib.gz")
+    assert result == plain
+
+
+# ---------------------------------------------------------------------------
+# read_input_file_list
+# ---------------------------------------------------------------------------
+
+
+def test_read_input_file_list_returns_lines(tmp_path):
+    f = tmp_path / "files.txt"
+    f.write_text("a.root\nb.root\nc.root\n")
+    result = read_input_file_list(f)
+    assert result == ["a.root", "b.root", "c.root"]
+
+
+def test_read_input_file_list_skips_blank_lines(tmp_path):
+    f = tmp_path / "files.txt"
+    f.write_text("a.root\n\nb.root\n   \n")
+    result = read_input_file_list(f)
+    assert result == ["a.root", "b.root"]
+
+
+def test_read_input_file_list_missing_file_raises(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        read_input_file_list(tmp_path / "missing.txt")
+
+
+def test_read_input_file_list_empty_file_raises(tmp_path):
+    f = tmp_path / "empty.txt"
+    f.write_text("")
+    with pytest.raises(ValueError, match="No input files"):
+        read_input_file_list(f)
+
+
+# ---------------------------------------------------------------------------
+# parse_image_selection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("input_str", "expected"),
+    [
+        ("15", [0, 1, 2, 3]),  # 0b1111
+        ("14", [1, 2, 3]),  # 0b1110
+        ("1", [0]),  # 0b0001
+        ("8", [3]),  # 0b1000
+        ("0", []),  # all bits off
+    ],
+)
+def test_parse_image_selection_bit_coded(input_str, expected):
+    assert parse_image_selection(input_str) == expected
+
+
+def test_parse_image_selection_comma_separated():
+    assert parse_image_selection("1,2,3") == [1, 2, 3]
+
+
+def test_parse_image_selection_comma_with_spaces():
+    assert parse_image_selection("0, 2, 3") == [0, 2, 3]
+
+
+def test_parse_image_selection_empty_returns_none():
+    assert parse_image_selection("") is None
+    assert parse_image_selection(None) is None
+
+
+def test_parse_image_selection_invalid_raises():
+    with pytest.raises(ValueError, match="Invalid image_selection"):
+        parse_image_selection("abc")
+
+
+# ---------------------------------------------------------------------------
+# load_model_parameters
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def model_params_file(tmp_path):
+    params = {
+        "energy_bins_log10_tev": [
+            {"E_min": -1.0, "E_max": 0.0},
+            {"E_min": 0.0, "E_max": 1.0},
+        ],
+        "zenith_bins_deg": [{"Ze_min": 0, "Ze_max": 30}],
+    }
+    f = tmp_path / "params.json"
+    f.write_text(json.dumps(params))
+    return f, params
+
+
+def test_load_model_parameters_returns_full_dict(model_params_file):
+    f, params = model_params_file
+    result = load_model_parameters(f)
+    assert result["energy_bins_log10_tev"] == params["energy_bins_log10_tev"]
+    assert result["zenith_bins_deg"] == params["zenith_bins_deg"]
+
+
+def test_load_model_parameters_selects_energy_bin(model_params_file):
+    f, _ = model_params_file
+    result = load_model_parameters(f, energy_bin_number=1)
+    assert result["energy_bins_log10_tev"] == {"E_min": 0.0, "E_max": 1.0}
+
+
+def test_load_model_parameters_invalid_bin_raises(model_params_file):
+    f, _ = model_params_file
+    with pytest.raises(ValueError, match="Invalid energy bin number"):
+        load_model_parameters(f, energy_bin_number=99)
+
+
+def test_load_model_parameters_missing_file_raises():
+    with pytest.raises(FileNotFoundError):
+        load_model_parameters("/nonexistent/path.json")
+
+
+# ---------------------------------------------------------------------------
+# load_energy_range
+# ---------------------------------------------------------------------------
+
+
+def test_load_energy_range_returns_power_of_ten():
+    params = {"energy_bins_log10_tev": {"E_min": -1.0, "E_max": 1.0}}
+    e_min, e_max = load_energy_range(params)
+    assert e_min == pytest.approx(0.1)
+    assert e_max == pytest.approx(10.0)
+
+
+def test_load_energy_range_missing_key_raises():
+    with pytest.raises(ValueError, match="Invalid or missing energy range"):
+        load_energy_range({"other_key": {}})
+
+
+def test_load_energy_range_missing_inner_key_raises():
+    with pytest.raises((ValueError, KeyError)):
+        load_energy_range({"energy_bins_log10_tev": {"E_min": -1.0}})
+
+
+# ---------------------------------------------------------------------------
+# output_file_name
+# ---------------------------------------------------------------------------
+
+
+def test_output_file_name_basic(tmp_path):
+    result = output_file_name(tmp_path / "model")
+    assert str(result).endswith(".joblib.gz")
+
+
+def test_output_file_name_with_ntel(tmp_path):
+    result = output_file_name(tmp_path / "model", n_tel=4)
+    assert "_ntel4" in str(result)
+    assert str(result).endswith(".joblib.gz")
+
+
+def test_output_file_name_with_energy_bin(tmp_path):
+    result = output_file_name(tmp_path / "model", energy_bin_number=2)
+    assert "_ebin2" in str(result)
+
+
+def test_output_file_name_creates_parent_directory(tmp_path):
+    nested = tmp_path / "subdir" / "model"
+    output_file_name(nested)
+    assert (tmp_path / "subdir").is_dir()
+
+
+def test_output_file_name_returns_path_object(tmp_path):
+    result = output_file_name(tmp_path / "model")
+    assert isinstance(result, str)


### PR DESCRIPTION
- Add 12 new test files covering all production modules
- Raise overall test coverage to 92%
- Fix E5: process_file_chunked uses features_tmva_style when tmva_style=True
- Fix E6: configure_training no longer raises AttributeError when energy_bins_log10_tev is absent (fallback changed from [] to {})
- Add regression tests for both bugs
- Add diagnostics/ to .gitignore